### PR TITLE
Add the `ServiceMonitor` resource for `kube-dns` `Service`

### DIFF
--- a/flux/cluster/core-dns.yaml
+++ b/flux/cluster/core-dns.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: core-dns
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: baseline
+  path: core-dns
+  interval: 1h
+  retryInterval: 10m
+  prune: true

--- a/flux/cluster/kustomization.yaml
+++ b/flux/cluster/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - sources.yaml
   - custom-resources.yaml
   - flux.yaml
+  - core-dns.yaml

--- a/flux/core-dns/kustomization.yaml
+++ b/flux/core-dns/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: core-dns
+namespace: kube-system
+resources:
+  - service-monitor.yaml

--- a/flux/core-dns/service-monitor.yaml
+++ b/flux/core-dns/service-monitor.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    app.kubernetes.io/name: coredns
+spec:
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      port: metrics
+      interval: 15s


### PR DESCRIPTION
Add the `ServiceMonitor` resource ready for Prometheus to enable monitoring of the `kube-dns` Service (i.e. CoreDNS) inside the Kubernetes clusters.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
