### PR TITLE
Add `proxmox-csi` CSI Driver for the Clustsrs

### DIFF
--- a/flux/cluster/kustomization.yaml
+++ b/flux/cluster/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - custom-resources.yaml
   - flux.yaml
   - core-dns.yaml
+  - proxmox-csi.yaml

--- a/flux/cluster/proxmox-csi.yaml
+++ b/flux/cluster/proxmox-csi.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: proxmox-csi
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: baseline
+  path: proxmox-csi
+  dependsOn:
+    - name: sources
+    - name: prometheus-crds
+  interval: 1h
+  retryInterval: 10m
+  prune: true
+
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: proxmox-csi-substitutions
+      - kind: Secret
+        name: proxmox-csi-substitutions

--- a/flux/proxmox-csi/kustomization.yaml
+++ b/flux/proxmox-csi/kustomization.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: proxmox-csi-plugin
+  namespace: flux-system
+namespace: proxmox-system
+
+resources:
+  - namespace.yaml
+  - proxmox-csi-helm.yaml
+  - proxmox-csi-secrets.yaml
+
+commonLabels:
+  flux.kub3.uk/organisation: n3tuk
+  flux.kub3.uk/repository: infra-flux
+  flux.kub3.uk/kustomization: proxmox
+  flux.kub3.uk/application: proxmox
+  flux.kub3.uk/component: csi
+
+configMapGenerator:
+  - name: helm-proxmox-csi-values
+    files:
+      - values.yaml=proxmox-csi-values.yaml
+
+configurations:
+  - kustomize-config.yaml

--- a/flux/proxmox-csi/kustomize-config.yaml
+++ b/flux/proxmox-csi/kustomize-config.yaml
@@ -1,0 +1,18 @@
+---
+# Automatically update the reference to the ConfigMap containing the HelmRelease
+# values, forcing the resource to reconcile on changes to the configuration
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease
+
+  # Also override the name for the Secret resource created through this
+  # Kustomization as the above specification will override all name arguments
+  # under valuesFrom
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: metadata/name
+        kind: Secret

--- a/flux/proxmox-csi/namespace.yaml
+++ b/flux/proxmox-csi/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: proxmox-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline

--- a/flux/proxmox-csi/proxmox-csi-helm.yaml
+++ b/flux/proxmox-csi/proxmox-csi-helm.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: proxmox-csi
+spec:
+  chartRef:
+    kind: OCIRepository
+    namespace: flux-system
+    name: proxmox-csi-plugin
+  interval: 1h
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  test:
+    enable: true
+  driftDetection:
+    mode: enabled
+
+  valuesFrom:
+    - kind: ConfigMap
+      name: helm-proxmox-csi-values
+    - kind: Secret
+      name: helm-proxmox-csi-values

--- a/flux/proxmox-csi/proxmox-csi-secrets.yaml
+++ b/flux/proxmox-csi/proxmox-csi-secrets.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: helm-proxmox-csi-values
+stringData:
+  values.yaml: |-
+    ---
+    config:
+      clusters:
+        - url: ${proxmox_csi_url}
+          token_id: ${proxmox_csi_token_id}
+          token_secret: ${proxmox_csi_token_secret}
+          region: ${proxmox_csi_region}

--- a/flux/proxmox-csi/proxmox-csi-values.yaml
+++ b/flux/proxmox-csi/proxmox-csi-values.yaml
@@ -1,0 +1,37 @@
+---
+fullnameOverride: proxmox-csi
+
+storageClass:
+  - name: proxmox-rbd-xfs
+    storage: kub3-rbd
+    cache: writethrough
+    ssd: true
+    fstype: xfs
+    mountOptions:
+      - discard
+      - noatime
+    allowVolumeExpansion: true
+    volumeBindingMode: WaitForFirstConsumer
+    reclaimPolicy: Delete
+  - name: proxmox-rbd-ext4
+    storage: kub3-rbd
+    cache: writethrough
+    ssd: true
+    fstype: ext4
+    mountOptions:
+      - discard
+      - noatime
+    allowVolumeExpansion: true
+    volumeBindingMode: WaitForFirstConsumer
+    reclaimPolicy: Delete
+
+metrics:
+  enabled: true
+
+# These services can run on the Control Plane so that any general issues with
+# worker nodes will not affect the processing of PVCs within the cluster
+nodeSelector:
+  node-role.kubernetes.io/control-plane: ''
+tolerations:
+  - key: node-role.kubernetes.io/control-plane
+    effect: NoSchedule

--- a/flux/sources/kustomization.yaml
+++ b/flux/sources/kustomization.yaml
@@ -6,3 +6,4 @@ metadata:
 namespace: flux-system
 resources:
   - flux-community.yaml
+  - proxmox-csi.yaml

--- a/flux/sources/proxmox-csi.yaml
+++ b/flux/sources/proxmox-csi.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: proxmox-csi-plugin
+spec:
+  secretRef:
+    name: ghcr-login
+  provider: generic
+  interval: 24h
+  url: oci://ghcr.io/sergelogvinov/charts/proxmox-csi-plugin
+  ref:
+    semver: 0.2.13
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -28,14 +28,18 @@ No modules.
 | Name | Type |
 |------|------|
 | [kubernetes_config_map_v1.common_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
+| [kubernetes_config_map_v1.proxmox_csi_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
 | [kubernetes_manifest.flux_system_baseline](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.flux_system_cluster](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_secret_v1.proxmox_csi_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_domain"></a> [cluster\_domain](#input\_cluster\_domain) | The external domain name of the EKS Cluster (i.e. the domain suffix for deployed services) | `string` | n/a | yes |
+| <a name="input_proxmox_csi_plugin_token_id"></a> [proxmox\_csi\_plugin\_token\_id](#input\_proxmox\_csi\_plugin\_token\_id) | The API token name to provide the proxmox-csi-plugin resource access to the Proxmox API for Ceph | `string` | n/a | yes |
+| <a name="input_proxmox_csi_plugin_token_secret"></a> [proxmox\_csi\_plugin\_token\_secret](#input\_proxmox\_csi\_plugin\_token\_secret) | The API token secret to provide the proxmox-csi-plugin resource access to the Proxmox API for Ceph | `string` | n/a | yes |
 | <a name="input_root_domain"></a> [root\_domain](#input\_root\_domain) | The root external domain name of the EKS Cluster (i.e. the domain suffix for selected services) | `string` | n/a | yes |
 | <a name="input_sit3_domain"></a> [sit3\_domain](#input\_sit3\_domain) | The external domain name of the EKS Cluster using the sit3.uk domain | `string` | n/a | yes |
 | <a name="input_t3st_domain"></a> [t3st\_domain](#input\_t3st\_domain) | The external domain name of the EKS Cluster using the t3st.uk domain | `string` | n/a | yes |

--- a/terraform/proxmox-csi.tf
+++ b/terraform/proxmox-csi.tf
@@ -1,0 +1,35 @@
+resource "kubernetes_config_map_v1" "proxmox_csi_substitutions" {
+  metadata {
+    name      = "proxmox-csi-substitutions"
+    namespace = "flux-system"
+
+    labels = merge(local.kubernetes_labels, {
+      "kub3.uk/name"     = "proxmox-csi"
+      "kub3.uk/instance" = "proxmox-csi"
+    })
+  }
+
+  data = {
+    proxmox_csi_url      = "https://proxmox.${var.cluster_domain}:8006/api2/json"
+    proxmox_csi_token_id = var.proxmox_csi_plugin_token_id
+    proxmox_csi_region   = terraform.workspace
+  }
+}
+
+resource "kubernetes_secret_v1" "proxmox_csi_substitutions" {
+  metadata {
+    name      = "proxmox-csi-substitutions"
+    namespace = "flux-system"
+
+    labels = merge(local.kubernetes_labels, {
+      "kub3.uk/name"     = "proxmox-csi"
+      "kub3.uk/instance" = "proxmox-csi"
+    })
+  }
+
+  type = "Opaque"
+
+  data = {
+    proxmox_csi_token_secret = var.proxmox_csi_plugin_token_secret
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -53,3 +53,15 @@ variable "flux_artifact_tag" {
   type        = string
   default     = "latest"
 }
+
+variable "proxmox_csi_plugin_token_id" {
+  description = "The API token name to provide the proxmox-csi-plugin resource access to the Proxmox API for Ceph"
+  type        = string
+  # required
+}
+
+variable "proxmox_csi_plugin_token_secret" {
+  description = "The API token secret to provide the proxmox-csi-plugin resource access to the Proxmox API for Ceph"
+  type        = string
+  # required
+}

--- a/terraform/variables/production.tfvars
+++ b/terraform/variables/production.tfvars
@@ -2,3 +2,6 @@ cluster_domain = "p.kub3.uk"
 root_domain    = "kub3.uk"
 t3st_domain    = "t3st.uk"
 sit3_domain    = "sit3.uk"
+
+proxmox_csi_plugin_token_id     = "kubernetes-csi@pve!csi"
+proxmox_csi_plugin_token_secret = ""


### PR DESCRIPTION
Add the `proxmox-csi` CSI Driver for the Kubernetes Clusters to allow access to the Ceph distributed store inside Proxmox, which can be used to create and manage PVCs inside the clusters.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
