### PR TITLE
Add `metrics-server` deployment

### DIFF
--- a/flux/cluster/kustomization.yaml
+++ b/flux/cluster/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - flux.yaml
   - core-dns.yaml
   - proxmox-csi.yaml
+  - metrics-server.yaml

--- a/flux/cluster/metrics-server.yaml
+++ b/flux/cluster/metrics-server.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: metrics-server
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: baseline
+  path: metrics-server
+  dependsOn:
+    - name: prometheus-crds
+  interval: 1h
+  retryInterval: 10m
+  prune: true
+
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-substitutions

--- a/flux/metrics-server/kustomization.yaml
+++ b/flux/metrics-server/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: metrics-server
+  namespace: flux-system
+namespace: kube-system
+resources:
+  - metrics-server-helm.yaml
+configMapGenerator:
+  - name: helm-metrics-server-values
+    options:
+      disableNameSuffixHash: true
+    files:
+      - values.yaml=metrics-server-values.yaml

--- a/flux/metrics-server/metrics-server-helm.yaml
+++ b/flux/metrics-server/metrics-server-helm.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: metrics-server
+spec:
+  chart:
+    spec:
+      sourceRef:
+        kind: HelmRepository
+        namespace: flux-system
+        name: metrics-server
+      chart: metrics-server
+      interval: 5m
+      version: 3.12.2
+  interval: 3h
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  test:
+    enable: true
+  driftDetection:
+    mode: enabled
+
+  valuesFrom:
+    - kind: ConfigMap
+      name: helm-metrics-server-values

--- a/flux/metrics-server/metrics-server-values.yaml
+++ b/flux/metrics-server/metrics-server-values.yaml
@@ -1,0 +1,46 @@
+---
+replicas: 2
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: metrics-server
+        app.kubernetes.io/instance: metrics-server
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: metrics-server
+        app.kubernetes.io/instance: metrics-server
+
+defaultArgs:
+  - --cert-dir=/tmp
+  - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+  - --kubelet-use-node-status-port
+  - --kubelet-insecure-tls
+  - --metric-resolution=15s
+
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+metrics:
+  enabled: true
+
+serviceMonitor:
+  enabled: true
+
+resources:
+  limits: {}
+  requests:
+    memory: 64Mi
+    cpu: 10m

--- a/flux/sources/kustomization.yaml
+++ b/flux/sources/kustomization.yaml
@@ -7,3 +7,4 @@ namespace: flux-system
 resources:
   - flux-community.yaml
   - proxmox-csi.yaml
+  - metrics-server.yaml

--- a/flux/sources/metrics-server.yaml
+++ b/flux/sources/metrics-server.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: metrics-server
+spec:
+  url: https://kubernetes-sigs.github.io/metrics-server/
+  interval: 24h


### PR DESCRIPTION
Add a deployment of the `metrics-server` service which will provide all Pod and Node metrics for CLIs, TUIs, and (eventually) KEDA management of Deployments and StatefulSets.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
