### PR TITLE
Add `cloudflared` Cloudflare Tunnel service

### DIFF
--- a/flux/cert-manager-crds/kustomization.yaml
+++ b/flux/cert-manager-crds/kustomization.yaml
@@ -9,8 +9,10 @@ commonLabels:
   flux.kub3.uk/organisation: n3tuk
   flux.kub3.uk/repository: infra-flux
   flux.kub3.uk/kustomization: cert-manager-crds
+  flux.kub3.uk/name: cert-manager
   flux.kub3.uk/application: cert-manager
   flux.kub3.uk/component: cert-manager
+  flux.kub3.uk/managed-by: kustomization
 
 resources:
   - resources.yaml

--- a/flux/cloudflared/cloudflared-helm.yaml
+++ b/flux/cloudflared/cloudflared-helm.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: cloudflared
+spec:
+  chart:
+    spec:
+      sourceRef:
+        kind: HelmRepository
+        namespace: flux-system
+        name: cloudflare
+      chart: cloudflare-tunnel
+      interval: 5m
+      version: 0.3.2
+  interval: 3h
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  test:
+    enable: true
+  driftDetection:
+    mode: enabled
+
+  valuesFrom:
+    - kind: ConfigMap
+      name: helm-cloudflared-values

--- a/flux/cloudflared/cloudflared-secrets.yaml
+++ b/flux/cloudflared/cloudflared-secrets.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflared-credentials
+stringData:
+  credentials.json: |-
+    {
+      "AccountTag":"${cloudflared_account_id}",
+      "TunnelSecret":"${cloudflared_tunnel_secret}",
+      "TunnelName":"${cloudflared_tunnel_name}",
+      "TunnelID": "${cloudflared_tunnel_id}"
+    }

--- a/flux/cloudflared/cloudflared-values.yaml
+++ b/flux/cloudflared/cloudflared-values.yaml
@@ -1,0 +1,21 @@
+---
+fullnameOverride: tunnel
+replicaCount: 2
+
+cloudflare:
+  tunnelName: ${cloudflared_tunnel_name}
+  secretName: cloudflared-credentials
+
+image:
+  tag: 2024.11.1
+
+resources:
+  limits: # Don't limit the CPU
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault

--- a/flux/cloudflared/kustomization.yaml
+++ b/flux/cloudflared/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: cloudflared
+  namespace: flux-system
+namespace: cloudflared-system
+
+resources:
+  - namespace.yaml
+  - cloudflared-helm.yaml
+  - cloudflared-secrets.yaml
+
+commonLabels:
+  flux.kub3.uk/organisation: n3tuk
+  flux.kub3.uk/repository: infra-flux
+  flux.kub3.uk/kustomization: cloudflared
+  flux.kub3.uk/name: cloudflared
+  flux.kub3.uk/application: cloudflared
+  flux.kub3.uk/component: tunnel
+  flux.kub3.uk/managed-by: kustomization
+
+configMapGenerator:
+  - name: helm-cloudflared-values
+    files:
+      - values.yaml=cloudflared-values.yaml
+
+configurations:
+  - kustomize-config.yaml

--- a/flux/cloudflared/kustomize-config.yaml
+++ b/flux/cloudflared/kustomize-config.yaml
@@ -1,0 +1,9 @@
+---
+# Automatically update the reference to the ConfigMap containing the HelmRelease
+# values, forcing the resource to reconcile on changes to the configuration
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/flux/cloudflared/namespace.yaml
+++ b/flux/cloudflared/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloudflared-system

--- a/flux/cluster/cloudflared.yaml
+++ b/flux/cluster/cloudflared.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cloudflared
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: baseline
+  path: cloudflared
+  dependsOn:
+    - name: sources
+  interval: 1h
+  retryInterval: 10m
+  prune: true
+
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cloudflared-substitutions
+      - kind: Secret
+        name: cloudflared-substitutions

--- a/flux/cluster/kustomization.yaml
+++ b/flux/cluster/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - core-dns.yaml
   - proxmox-csi.yaml
   - metrics-server.yaml
+  - cloudflared.yaml

--- a/flux/core-dns/kustomization.yaml
+++ b/flux/core-dns/kustomization.yaml
@@ -4,5 +4,15 @@ kind: Kustomization
 metadata:
   name: core-dns
 namespace: kube-system
+
 resources:
   - service-monitor.yaml
+
+commonLabels:
+  flux.kub3.uk/organisation: n3tuk
+  flux.kub3.uk/repository: infra-flux
+  flux.kub3.uk/kustomization: core-dns
+  flux.kub3.uk/name: core-dns
+  flux.kub3.uk/application: core-dns
+  flux.kub3.uk/component: service-monitor
+  flux.kub3.uk/managed-by: kustomization

--- a/flux/flux/kustomization.yaml
+++ b/flux/flux/kustomization.yaml
@@ -9,6 +9,15 @@ resources:
   # Namespace already created during bootstrapping
   - flux-helm.yaml
 
+commonLabels:
+  flux.kub3.uk/organisation: n3tuk
+  flux.kub3.uk/repository: infra-flux
+  flux.kub3.uk/kustomization: flux
+  flux.kub3.uk/name: flux
+  flux.kub3.uk/application: flux
+  flux.kub3.uk/component: flux
+  flux.kub3.uk/managed-by: kustomization
+
 configMapGenerator:
   - name: helm-flux-values
     options:

--- a/flux/grafana-crds/kustomization.yaml
+++ b/flux/grafana-crds/kustomization.yaml
@@ -9,8 +9,10 @@ commonLabels:
   flux.kub3.uk/organisation: n3tuk
   flux.kub3.uk/repository: infra-flux
   flux.kub3.uk/kustomization: grafana-crds
+  flux.kub3.uk/name: grafana-operator
   flux.kub3.uk/application: grafana
   flux.kub3.uk/component: grafana-operator
+  flux.kub3.uk/managed-by: kustomization
 
 resources:
   - namespace.yaml

--- a/flux/grafana-crds/namespace.yaml
+++ b/flux/grafana-crds/namespace.yaml
@@ -3,6 +3,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: grafana-operator
-  labels:
-    app.kubernetes.io/managed-by: Kustomization
-    app.kubernetes.io/name: grafana-operator

--- a/flux/metrics-server/kustomization.yaml
+++ b/flux/metrics-server/kustomization.yaml
@@ -5,8 +5,19 @@ metadata:
   name: metrics-server
   namespace: flux-system
 namespace: kube-system
+
 resources:
   - metrics-server-helm.yaml
+
+commonLabels:
+  flux.kub3.uk/organisation: n3tuk
+  flux.kub3.uk/repository: infra-flux
+  flux.kub3.uk/kustomization: metrics-server
+  flux.kub3.uk/name: metrics-server
+  flux.kub3.uk/application: metrics-server
+  flux.kub3.uk/component: metrics-server
+  flux.kub3.uk/managed-by: kustomization
+
 configMapGenerator:
   - name: helm-metrics-server-values
     options:

--- a/flux/prometheus-crds/kustomization.yaml
+++ b/flux/prometheus-crds/kustomization.yaml
@@ -9,8 +9,10 @@ commonLabels:
   flux.kub3.uk/organisation: n3tuk
   flux.kub3.uk/repository: infra-flux
   flux.kub3.uk/kustomization: prometheus-crds
+  flux.kub3.uk/name: prometheus
   flux.kub3.uk/application: prometheus
   flux.kub3.uk/component: prometheus-operator
+  flux.kub3.uk/managed-by: kustomization
 
 resources:
   - namespace.yaml

--- a/flux/proxmox-csi/kustomization.yaml
+++ b/flux/proxmox-csi/kustomization.yaml
@@ -15,8 +15,10 @@ commonLabels:
   flux.kub3.uk/organisation: n3tuk
   flux.kub3.uk/repository: infra-flux
   flux.kub3.uk/kustomization: proxmox
+  flux.kub3.uk/name: proxmox
   flux.kub3.uk/application: proxmox
   flux.kub3.uk/component: csi
+  flux.kub3.uk/managed-by: kustomization
 
 configMapGenerator:
   - name: helm-proxmox-csi-values

--- a/flux/sources/cloudflare.yaml
+++ b/flux/sources/cloudflare.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: cloudflare
+spec:
+  url: https://cloudflare.github.io/helm-charts
+  interval: 24h

--- a/flux/sources/kustomization.yaml
+++ b/flux/sources/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - flux-community.yaml
   - proxmox-csi.yaml
   - metrics-server.yaml
+  - cloudflare.yaml

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -10,14 +10,18 @@ TODO
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.10.0 |
+| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 4.23 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.6 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.25.2 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | 4.43.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.25.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
 
 ## Modules
 
@@ -27,11 +31,16 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [cloudflare_zero_trust_tunnel_cloudflared.cluster](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_cloudflared) | resource |
+| [cloudflare_zero_trust_tunnel_cloudflared_config.cluster](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_cloudflared_config) | resource |
 | [kubernetes_config_map_v1.common_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
+| [kubernetes_config_map_v1.flux_system_cloudflared_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
 | [kubernetes_config_map_v1.proxmox_csi_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
 | [kubernetes_manifest.flux_system_baseline](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.flux_system_cluster](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_secret_v1.flux_system_cloudflared_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [kubernetes_secret_v1.proxmox_csi_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [random_password.tunnel](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 
 ## Inputs
 
@@ -43,6 +52,7 @@ No modules.
 | <a name="input_root_domain"></a> [root\_domain](#input\_root\_domain) | The root external domain name of the EKS Cluster (i.e. the domain suffix for selected services) | `string` | n/a | yes |
 | <a name="input_sit3_domain"></a> [sit3\_domain](#input\_sit3\_domain) | The external domain name of the EKS Cluster using the sit3.uk domain | `string` | n/a | yes |
 | <a name="input_t3st_domain"></a> [t3st\_domain](#input\_t3st\_domain) | The external domain name of the EKS Cluster using the t3st.uk domain | `string` | n/a | yes |
+| <a name="input_cloudflare_account_id"></a> [cloudflare\_account\_id](#input\_cloudflare\_account\_id) | The Account ID for the Cloudflare account to be used | `string` | `"e0d4aae3f32f077cd16bbc26f615738d"` | no |
 | <a name="input_flux_artifact_repository"></a> [flux\_artifact\_repository](#input\_flux\_artifact\_repository) | The path to the repository for the Flux artifact to be uploaded to in GHCR | `string` | `"n3tuk/flux/baseline"` | no |
 | <a name="input_flux_artifact_tag"></a> [flux\_artifact\_tag](#input\_flux\_artifact\_tag) | The tag of the Flux artifact uploaded to GHCR which should be deployed to this cluster | `string` | `"latest"` | no |
 

--- a/terraform/cloudflare-tunnel.tf
+++ b/terraform/cloudflare-tunnel.tf
@@ -1,0 +1,78 @@
+resource "random_password" "tunnel" {
+  length = 128
+
+  lower   = true
+  upper   = true
+  numeric = true
+  special = true
+}
+
+# Create and configure a tunnel in Cloudflare specific for this Kubernetes
+# Cluster, and then configure the namespace and additional configuration
+# directly into the Cluster
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "cluster" {
+  account_id = var.cloudflare_account_id
+
+  name   = "kub3-${terraform.workspace}"
+  secret = base64sha256(random_password.tunnel.result)
+}
+
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "cluster" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.cluster.id
+
+  config {
+    dynamic "ingress_rule" {
+      for_each = local.cloudflare_domains
+
+      content {
+        hostname = "*.${ingress_rule.value}"
+        service  = "http://external-controller.ingress-system.svc"
+        origin_request {
+          connect_timeout = "10s"
+        }
+      }
+    }
+
+    ingress_rule {
+      service = "http://external-controller.ingress-nginx.svc"
+    }
+  }
+}
+
+resource "kubernetes_config_map_v1" "flux_system_cloudflared_substitutions" {
+  metadata {
+    name      = "cloudflared-substitutions"
+    namespace = "flux-system"
+
+    labels = merge(local.kubernetes_labels, {
+      "flux.kub3.uk/name"     = "cloudflared"
+      "flux.kub3.uk/instance" = "cloudflared"
+    })
+  }
+
+  data = {
+    cloudflared_account_id  = var.cloudflare_account_id
+    cloudflared_tunnel_name = cloudflare_zero_trust_tunnel_cloudflared.cluster.name
+    cloudflared_tunnel_id   = cloudflare_zero_trust_tunnel_cloudflared.cluster.id
+  }
+}
+
+resource "kubernetes_secret_v1" "flux_system_cloudflared_substitutions" {
+  metadata {
+    name      = "cloudflared-substitutions"
+    namespace = "flux-system"
+
+    labels = merge(local.kubernetes_labels, {
+      "flux.kub3.uk/name"     = "cloudflared"
+      "flux.kub3.uk/instance" = "cloudflared"
+    })
+  }
+
+  type = "Opaque"
+
+  data = {
+    cloudflared_tunnel_secret = base64sha256(random_password.tunnel.result)
+  }
+}

--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -6,6 +6,11 @@ resource "kubernetes_config_map_v1" "common_substitutions" {
   metadata {
     name      = "common-substitutions"
     namespace = "flux-system"
+
+    labels = merge(local.kubernetes_labels, {
+      "flux.kub3.uk/name"     = "flux"
+      "flux.kub3.uk/instance" = "flux"
+    })
   }
 
   data = {

--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -19,5 +19,7 @@ resource "kubernetes_config_map_v1" "common_substitutions" {
     root_domain    = var.root_domain
     t3st_domain    = var.t3st_domain
     sit3_domain    = var.sit3_domain
+
+    cloudflare_tunnel = cloudflare_zero_trust_tunnel_cloudflared.cluster.cname
   }
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,4 +1,12 @@
 locals {
+  cloudflare_domains = [
+    "kub3.uk",
+    "pip3.uk",
+    "sit3.uk",
+    "liv3.uk",
+    "t3st.uk",
+  ]
+
   kubernetes_labels = {
     "flux.kub3.uk/managed-by" = "terraform"
     "flux.kub3.uk/repository" = "infra-flux"

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,7 +1,7 @@
 locals {
   kubernetes_labels = {
-    "kub3.uk/managed-by" = "Terraform"
-    "kub3.uk/repository" = "infra-flux"
-    "kub3.uk/cluster"    = terraform.workspace
+    "flux.kub3.uk/managed-by" = "terraform"
+    "flux.kub3.uk/repository" = "infra-flux"
+    "flux.kub3.uk/cluster"    = terraform.workspace
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,7 +12,11 @@ resource "kubernetes_manifest" "flux_system_baseline" {
     "metadata" = {
       "name"      = "baseline"
       "namespace" = "flux-system"
-      "labels"    = local.kubernetes_labels
+
+      "labels" = merge(local.kubernetes_labels, {
+        "flux.kub3.uk/name"     = "flux"
+        "flux.kub3.uk/instance" = "flux"
+      })
     }
 
     "spec" = {
@@ -37,7 +41,11 @@ resource "kubernetes_manifest" "flux_system_cluster" {
     "metadata" = {
       "name"      = "cluster"
       "namespace" = "flux-system"
-      "labels"    = local.kubernetes_labels
+
+      "labels" = merge(local.kubernetes_labels, {
+        "flux.kub3.uk/name"     = "flux"
+        "flux.kub3.uk/instance" = "flux"
+      })
     }
 
     "spec" = {

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -4,7 +4,7 @@ provider "google" {
   zone    = "europe-west2-a"
 
   default_labels = {
-    environment = "development"
+    environment = terraform.workspace
     deployer    = "terraform"
     owner       = "jonathan-n3t-uk"
   }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -10,6 +10,10 @@ provider "google" {
   }
 }
 
+provider "cloudflare" {
+  retries = 3
+}
+
 provider "kubernetes" {
   config_path    = "~/.kube/config.yaml"
   config_context = "admin@${terraform.workspace}"

--- a/terraform/proxmox-csi.tf
+++ b/terraform/proxmox-csi.tf
@@ -4,8 +4,8 @@ resource "kubernetes_config_map_v1" "proxmox_csi_substitutions" {
     namespace = "flux-system"
 
     labels = merge(local.kubernetes_labels, {
-      "kub3.uk/name"     = "proxmox-csi"
-      "kub3.uk/instance" = "proxmox-csi"
+      "flux.kub3.uk/name"     = "proxmox-csi"
+      "flux.kub3.uk/instance" = "proxmox-csi"
     })
   }
 
@@ -22,8 +22,8 @@ resource "kubernetes_secret_v1" "proxmox_csi_substitutions" {
     namespace = "flux-system"
 
     labels = merge(local.kubernetes_labels, {
-      "kub3.uk/name"     = "proxmox-csi"
-      "kub3.uk/instance" = "proxmox-csi"
+      "flux.kub3.uk/name"     = "proxmox-csi"
+      "flux.kub3.uk/instance" = "proxmox-csi"
     })
   }
 

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -6,9 +6,17 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 6.6"
     }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.23"
+    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "~> 2.25.2"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6.0"
     }
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -65,3 +65,9 @@ variable "proxmox_csi_plugin_token_secret" {
   type        = string
   # required
 }
+
+variable "cloudflare_account_id" {
+  description = "The Account ID for the Cloudflare account to be used"
+  type        = string
+  default     = "e0d4aae3f32f077cd16bbc26f615738d"
+}


### PR DESCRIPTION
Implement the `cloudflared` service to provide a Cloudflare Tunnel for external ingress into the Kubernetes clusters, with access, through the common substitutions to the common CNAME for future services.

Additionally, improve the standard labels used across both Terraform and Flux to a more common standard, and ensure the defaults are appropriately configured across all resources. Those created by `HelmResource` deployments have not yet been handled.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
