### PR TITLE
Implement `cert-manager` with `approver-policy`

### DIFF
--- a/flux/cert-manager/approver-policy-helm.yaml
+++ b/flux/cert-manager/approver-policy-helm.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: approver-policy
+spec:
+  chart:
+    spec:
+      sourceRef:
+        kind: HelmRepository
+        namespace: flux-system
+        name: jetstack
+      chart: cert-manager-approver-policy
+      interval: 5m
+      version: 0.17.0
+  interval: 3h
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  driftDetection:
+    mode: enabled
+  dependsOn:
+    - name: cert-manager
+
+  valuesFrom:
+    - kind: ConfigMap
+      name: helm-approver-policy-values

--- a/flux/cert-manager/approver-policy-values.yaml
+++ b/flux/cert-manager/approver-policy-values.yaml
@@ -1,0 +1,54 @@
+---
+crds:
+  enabled: true
+  keep: true
+
+replicaCount: 1
+
+app:
+  logFormat: json
+  logLevel: 4
+
+  approveSignerNames:
+    - issuers.cert-manager.io/*
+    - clusterissuers.cert-manager.io/*
+
+  metrics:
+    service:
+      enabled: true
+      servicemonitor:
+        enabled: true
+
+topologySpreadConstraints:
+  # With three Proxmox nodes and two workers per node, this will ensure that
+  # cert-manager is distributed across multiple nodes, not just multiple workers
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: cert-manager-approver-policy
+        app.kubernetes.io/instance: approver-policy
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: cert-manager-approver-policy
+        app.kubernetes.io/instance: approver-policy
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+resources:
+  limits: # Don't limit the CPU
+    memory: 128Mi
+  requests:
+    cpu: 10m
+    memory: 32Mi
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1

--- a/flux/cert-manager/approver-policy/approver-policy-helm.yaml
+++ b/flux/cert-manager/approver-policy/approver-policy-helm.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: approver-policy
+spec:
+  chart:
+    spec:
+      sourceRef:
+        kind: HelmRepository
+        namespace: flux-system
+        name: jetstack
+      chart: cert-manager-approver-policy
+      interval: 5m
+      version: 0.16.0
+  interval: 3h
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  driftDetection:
+    mode: enabled
+  dependsOn:
+    - name: cert-manager
+
+  valuesFrom:
+    - kind: ConfigMap
+      name: helm-approver-policy-values

--- a/flux/cert-manager/approver-policy/approver-policy-values.yaml
+++ b/flux/cert-manager/approver-policy/approver-policy-values.yaml
@@ -1,0 +1,58 @@
+---
+# The use of nameOverride does not work currently:
+#   https://github.com/cert-manager/approver-policy/issues/207
+# nameOverride: approver-policy
+
+crds:
+  enabled: true
+  keep: true
+
+replicaCount: 1
+
+app:
+  logFormat: json
+  logLevel: 4
+
+  approveSignerNames:
+    - issuers.cert-manager.io/*
+    - clusterissuers.cert-manager.io/*
+
+  metrics:
+    service:
+      enabled: true
+      servicemonitor:
+        enabled: true
+
+topologySpreadConstraints:
+  # With three Proxmox nodes and two workers per node, this will ensure that
+  # cert-manager is distributed across multiple nodes, not just multiple workers
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: cert-manager-approver-policy
+        app.kubernetes.io/instance: approver-policy
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: cert-manager-approver-policy
+        app.kubernetes.io/instance: approver-policy
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+resources:
+  limits: # Don't limit the CPU
+    memory: 128Mi
+  requests:
+    cpu: 10m
+    memory: 32Mi
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1

--- a/flux/cert-manager/approver-policy/kustomization.yaml
+++ b/flux/cert-manager/approver-policy/kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: cert-manager
+  namespace: flux-system
+namespace: certificates-system
+
+commonLabels:
+  flux.kub3.uk/component: cert-manager
+
+resources:
+  - approver-policy-helm.yaml
+
+configMapGenerator:
+  - name: helm-approver-policy-values
+    files:
+      - values.yaml=approver-policy-values.yaml
+
+configurations:
+  - kustomize-config.yaml

--- a/flux/cert-manager/approver-policy/kustomize-config.yaml
+++ b/flux/cert-manager/approver-policy/kustomize-config.yaml
@@ -1,0 +1,9 @@
+---
+# Automatically update the reference to the ConfigMap containing the HelmRelease
+# values, forcing the resource to reconcile on changes to the configuration
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/flux/cert-manager/cert-manager/cert-manager-helm.yaml
+++ b/flux/cert-manager/cert-manager/cert-manager-helm.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: cert-manager
+spec:
+  chart:
+    spec:
+      sourceRef:
+        kind: HelmRepository
+        namespace: flux-system
+        name: jetstack
+      chart: cert-manager
+      interval: 5m
+      version: 1.16.2
+  interval: 3h
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  test:
+    enable: true
+  driftDetection:
+    mode: enabled
+
+  valuesFrom:
+    - kind: ConfigMap
+      name: helm-cert-manager-values

--- a/flux/cert-manager/cert-manager/cert-manager-values.yaml
+++ b/flux/cert-manager/cert-manager/cert-manager-values.yaml
@@ -1,0 +1,178 @@
+---
+installCRDs: false
+
+dns01RecursiveNameservers: 1.1.1.1:53,1.0.0.1:53
+dns01RecursiveNameserversOnly: true
+
+global:
+  rbac:
+    create: true
+    aggregateClusterRoles: true
+
+  podSecurityPolicy:
+    enabled: false # No longer supported in Kubernetes
+
+  leaderElection:
+    namespace: certificates-system
+
+crds:
+  # The CRDs for cert-manager are managed by the custom-resource Kustomization
+  # within Flux, allowing resources to persist outside of this Helm Chart, and
+  # to break a dependency loop between cert-manager and Prometheus
+  enabled: false
+
+replicaCount: 1
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+enableCertificateOwnerRef: true
+
+# Prepare for making all approval decisions using approver-policy
+disableAutoApproval: true
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 64Mi
+
+topologySpreadConstraints:
+  # With three Proxmox nodes and two workers per node, this will ensure that
+  # cert-manager is distributed across multiple nodes, not just multiple workers
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/component: controller
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/component: controller
+
+prometheus:
+  enabled: true
+  servicemonitor:
+    enabled: true
+
+webhook:
+  replicaCount: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/instance: cert-manager
+          app.kubernetes.io/component: webhook
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/instance: cert-manager
+          app.kubernetes.io/component: webhook
+
+  networkPolicy:
+    enabled: false
+
+    ingress:
+      - from:
+          - ipBlock:
+              cidr: 0.0.0.0/0
+
+    egress:
+      - ports:
+          - port: 80
+            protocol: TCP
+          - port: 443
+            protocol: TCP
+        to:
+          - ipBlock:
+              cidr: 0.0.0.0/0
+      - ports:
+          - port: 53
+            protocol: TCP
+          - port: 53
+            protocol: UDP
+        to:
+          - ipBlock:
+              cidr: 172.20.0.10/32
+          - ipBlock:
+              cidr: 1.1.1.1/32
+          - ipBlock:
+              cidr: 1.0.0.1/32
+          - ipBlock:
+              cidr: 8.8.8.8/32
+          - ipBlock:
+              cidr: 8.8.4.4/32
+
+cainjector:
+  enabled: true
+  replicaCount: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+
+  resources:
+    requests:
+      cpu: 5m
+      memory: 64Mi
+
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/instance: cert-manager
+          app.kubernetes.io/component: cainjector
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/instance: cert-manager
+          app.kubernetes.io/component: cainjector
+
+startupapicheck:
+  enabled: true
+
+  resources:
+    limits: # Don't limit the CPU
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 32Mi

--- a/flux/cert-manager/cert-manager/kustomization.yaml
+++ b/flux/cert-manager/cert-manager/kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: cert-manager
+  namespace: flux-system
+namespace: certificates-system
+
+commonLabels:
+  flux.kub3.uk/component: cert-manager
+
+resources:
+  - cert-manager-helm.yaml
+
+configMapGenerator:
+  - name: helm-cert-manager-values
+    files:
+      - values.yaml=cert-manager-values.yaml
+
+configurations:
+  - kustomize-config.yaml

--- a/flux/cert-manager/cert-manager/kustomize-config.yaml
+++ b/flux/cert-manager/cert-manager/kustomize-config.yaml
@@ -1,0 +1,9 @@
+---
+# Automatically update the reference to the ConfigMap containing the HelmRelease
+# values, forcing the resource to reconcile on changes to the configuration
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/flux/cert-manager/kustomization.yaml
+++ b/flux/cert-manager/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: cert-manager
+  namespace: flux-system
+namespace: certificates-system
+
+commonLabels:
+  flux.kub3.uk/organisation: n3tuk
+  flux.kub3.uk/repository: infra-flux
+  flux.kub3.uk/name: cert-manager
+  flux.kub3.uk/kustomization: cert-manager
+  flux.kub3.uk/application: cert-manager
+  flux.kub3.uk/managed-by: kustomization
+
+resources:
+  - namespace.yaml
+  - cert-manager
+  - approver-policy

--- a/flux/cert-manager/namespace.yaml
+++ b/flux/cert-manager/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: certificates-system
+  labels:
+    flux.kub3.uk/component: cert-manager

--- a/flux/cluster/cert-manager.yaml
+++ b/flux/cluster/cert-manager.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cert-manager
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: baseline
+  path: cert-manager
+  dependsOn:
+    - name: sources
+    - name: cert-manager-crds
+    - name: prometheus-crds
+  interval: 1h
+  retryInterval: 10m
+  prune: true
+
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-substitutions

--- a/flux/cluster/kustomization.yaml
+++ b/flux/cluster/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - proxmox-csi.yaml
   - metrics-server.yaml
   - cloudflared.yaml
+  - cert-manager.yaml

--- a/flux/sources/jetstack.yaml
+++ b/flux/sources/jetstack.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: jetstack
+spec:
+  url: https://charts.jetstack.io
+  interval: 24h

--- a/flux/sources/kustomization.yaml
+++ b/flux/sources/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - proxmox-csi.yaml
   - metrics-server.yaml
   - cloudflare.yaml
+  - jetstack.yaml

--- a/terraform/cert-manager.tf
+++ b/terraform/cert-manager.tf
@@ -1,0 +1,46 @@
+data "cloudflare_api_token_permission_groups" "all" {}
+
+data "cloudflare_zone" "n3tuk" {
+  for_each = toset(local.cloudflare_domains)
+  name     = each.value
+}
+
+resource "cloudflare_api_token" "cert_manager" {
+  name = "cert-manager@${var.cluster_domain}"
+
+  policy {
+    permission_groups = [
+      data.cloudflare_api_token_permission_groups.all.zone["DNS Write"],
+      data.cloudflare_api_token_permission_groups.all.zone["SSL and Certificates Write"],
+    ]
+
+    resources = {
+      for zone in data.cloudflare_zone.n3tuk :
+      "com.cloudflare.api.account.zone.${zone.id}" => "*"
+    }
+  }
+
+  condition {
+    request_ip {
+      in = local.cloudflare_ip
+    }
+  }
+}
+
+resource "kubernetes_secret_v1" "flux_system_cert_manager_substitutions" {
+  metadata {
+    name      = "cert-manager-substitutions"
+    namespace = "flux-system"
+
+    labels = merge(local.kubernetes_labels, {
+      "flux.kub3.uk/name"     = "cert-manager"
+      "flux.kub3.uk/instance" = "cert-manager"
+    })
+  }
+
+  type = "Opaque"
+
+  data = {
+    "cloudflare_api_token" = cloudflare_api_token.cert_manager.value
+  }
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -7,6 +7,11 @@ locals {
     "t3st.uk",
   ]
 
+  cloudflare_ip = [
+    "82.69.106.64/32",
+    "2a02:8010:8006::/48",
+  ]
+
   kubernetes_labels = {
     "flux.kub3.uk/managed-by" = "terraform"
     "flux.kub3.uk/repository" = "infra-flux"


### PR DESCRIPTION
Implement the `cert-manager` service alongside `approver-policy` to provide automated `Certificate` management and approval control of these resources. The approval policy, in general, allows all resources currently, but this should be tightened in due course.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
