### PR TITLE
Add `ClusterIssuer` resources for `cert-manager`

### DIFF
--- a/flux/certificates/certificates.yaml
+++ b/flux/certificates/certificates.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: letsencrypt-cloudflare-staging
+  namespace: cert-manager
+spec:
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-cloudflare-staging
+  secretName: letsencrypt-cloudflare-staging-tls
+  privateKey:
+    algorithm: RSA
+    size: 4096
+  dnsNames:
+    - cloudflare.letsencrypt.certs.${cluster_domain}

--- a/flux/certificates/cloudflare-secrets.yaml
+++ b/flux/certificates/cloudflare-secrets.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflare-token
+  labels:
+    app.kubernetes.io/managed-by: Kustomization
+stringData:
+  api-token: ${cloudflare_api_token}

--- a/flux/certificates/cluster-policies.yaml
+++ b/flux/certificates/cluster-policies.yaml
@@ -1,0 +1,120 @@
+---
+# This policy configures all options to allow all possible values.
+apiVersion: policy.cert-manager.io/v1alpha1
+kind: CertificateRequestPolicy
+metadata:
+  name: allow-all
+spec:
+  allowed:
+    commonName:
+      value: '*'
+    dnsNames:
+      values:
+        - '*'
+    ipAddresses:
+      values:
+        - '*'
+    uris:
+      values:
+        - '*'
+    emailAddresses:
+      values:
+        - '*'
+    isCA: false
+    usages:
+      - server auth
+      - client auth
+      - digital signature
+      - key encipherment
+    subject:
+      organizations:
+        values:
+          - '*'
+      countries:
+        values:
+          - '*'
+      organizationalUnits:
+        values:
+          - '*'
+      localities:
+        values:
+          - '*'
+      provinces:
+        values:
+          - '*'
+      streetAddresses:
+        values:
+          - '*'
+      postalCodes:
+        values:
+          - '*'
+      serialNumber:
+        value: '*'
+  selector:
+    issuerRef: {}
+---
+# This policy configures all options to allow all possible values.
+apiVersion: policy.cert-manager.io/v1alpha1
+kind: CertificateRequestPolicy
+metadata:
+  name: ingress-nginx-ca
+spec:
+  allowed:
+    isCA: true
+    commonName:
+      value: ingress-nginx Private Certificate Authority
+      required: true
+    subject:
+      organizations:
+        values:
+          - n3t.uk Lab Environment
+      organizationalUnits:
+        values:
+          - n3tuk Kubernetes Clusters
+          - n3tuk Kubernetes Certificate Authority
+      provinces:
+        values:
+          - Bridgend
+      localities:
+        values:
+          - Wales
+      countries:
+        values:
+          - UK
+      streetAddresses:
+        values: []
+      postalCodes:
+        values: []
+  selector:
+    issuerRef:
+      group: cert-manager.io
+      kind: ClusterIssuer
+      name: self-signed
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-policy:allow
+rules:
+  - apiGroups:
+      - policy.cert-manager.io
+    resources:
+      - certificaterequestpolicies
+    verbs:
+      - use
+    resourceNames:
+      - allow-all
+      - ingress-nginx-ca
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-policy:allow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-policy:allow
+subjects:
+  - kind: Group
+    name: system:authenticated
+    apiGroup: rbac.authorization.k8s.io

--- a/flux/certificates/kustomization.yaml
+++ b/flux/certificates/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: certificates
+  namespace: flux-system
+namespace: certificates-system
+
+commonLabels:
+  flux.kub3.uk/organisation: n3tuk
+  flux.kub3.uk/repository: infra-flux
+  flux.kub3.uk/kustomization: cert-manager-crds
+  flux.kub3.uk/name: cert-manager
+  flux.kub3.uk/application: cert-manager
+  flux.kub3.uk/component: certificates
+  flux.kub3.uk/managed-by: kustomization
+
+resources:
+  - cloudflare-secrets.yaml
+  - letsencrypt.yaml
+  - cluster-policies.yaml
+  - certificates.yaml

--- a/flux/certificates/letsencrypt.yaml
+++ b/flux/certificates/letsencrypt.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-cloudflare-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: jon@than.io
+    privateKeySecretRef:
+      name: letsencrypt-cloudflare-staging
+    solvers:
+      - dns01:
+          cloudflare:
+            email: jon@than.io
+            apiTokenSecretRef:
+              name: cloudflare-token
+              key: api-token
+        selector:
+          dnsZones:
+            - n3t.uk
+            - kub3.uk
+            - pip3.uk
+            - t3st.uk
+            - liv3.uk
+            - sit3.uk
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-cloudflare-production
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: jon@than.io
+    privateKeySecretRef:
+      name: letsencrypt-cloudflare-production
+    solvers:
+      - dns01:
+          cloudflare:
+            email: jon@than.io
+            apiTokenSecretRef:
+              name: cloudflare-token
+              key: api-token
+        selector:
+          dnsZones:
+            - n3t.uk
+            - kub3.uk
+            - pip3.uk
+            - t3st.uk
+            - liv3.uk
+            - sit3.uk

--- a/flux/cluster/certificates.yaml
+++ b/flux/cluster/certificates.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: certificates
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: baseline
+  path: certificates
+  dependsOn:
+    - name: cert-manager
+  interval: 1h
+  retryInterval: 10m
+  prune: true
+
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-substitutions
+      - kind: Secret
+        name: cert-manager-substitutions

--- a/flux/cluster/kustomization.yaml
+++ b/flux/cluster/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - metrics-server.yaml
   - cloudflared.yaml
   - cert-manager.yaml
+  - certificates.yaml


### PR DESCRIPTION
Add the required `ClusterIssuer` resources (including creating API Keys via Terraform) to allow `Certificate` resources to be issued and managed, specifically enabling LetsEncrypt with Cloudflare DNS. A test `Certificate` is also included to monitor the resource.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
