### PR TITLE
Add `external-dns` with connection to Cloudflare

### DIFF
--- a/flux/cert-manager-crds/kustomization.yaml
+++ b/flux/cert-manager-crds/kustomization.yaml
@@ -5,14 +5,16 @@ metadata:
   name: cert-manager
 namespace: cert-manager
 
-commonLabels:
-  flux.kub3.uk/organisation: n3tuk
-  flux.kub3.uk/repository: infra-flux
-  flux.kub3.uk/kustomization: cert-manager-crds
-  flux.kub3.uk/name: cert-manager
-  flux.kub3.uk/application: cert-manager
-  flux.kub3.uk/component: cert-manager
-  flux.kub3.uk/managed-by: kustomization
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/kustomization: cert-manager-crds
+      flux.kub3.uk/name: cert-manager
+      flux.kub3.uk/application: cert-manager
+      flux.kub3.uk/component: cert-manager
+      flux.kub3.uk/managed-by: kustomization
 
 resources:
   - resources.yaml

--- a/flux/cert-manager/approver-policy/kustomization.yaml
+++ b/flux/cert-manager/approver-policy/kustomization.yaml
@@ -6,8 +6,10 @@ metadata:
   namespace: flux-system
 namespace: certificates-system
 
-commonLabels:
-  flux.kub3.uk/component: cert-manager
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/component: cert-manager
 
 resources:
   - approver-policy-helm.yaml

--- a/flux/cert-manager/cert-manager/kustomization.yaml
+++ b/flux/cert-manager/cert-manager/kustomization.yaml
@@ -6,8 +6,10 @@ metadata:
   namespace: flux-system
 namespace: certificates-system
 
-commonLabels:
-  flux.kub3.uk/component: cert-manager
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/component: cert-manager
 
 resources:
   - cert-manager-helm.yaml

--- a/flux/cert-manager/kustomization.yaml
+++ b/flux/cert-manager/kustomization.yaml
@@ -6,13 +6,15 @@ metadata:
   namespace: flux-system
 namespace: certificates-system
 
-commonLabels:
-  flux.kub3.uk/organisation: n3tuk
-  flux.kub3.uk/repository: infra-flux
-  flux.kub3.uk/name: cert-manager
-  flux.kub3.uk/kustomization: cert-manager
-  flux.kub3.uk/application: cert-manager
-  flux.kub3.uk/managed-by: kustomization
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/name: cert-manager
+      flux.kub3.uk/kustomization: cert-manager
+      flux.kub3.uk/application: cert-manager
+      flux.kub3.uk/managed-by: kustomization
 
 resources:
   - namespace.yaml

--- a/flux/certificates/kustomization.yaml
+++ b/flux/certificates/kustomization.yaml
@@ -6,14 +6,16 @@ metadata:
   namespace: flux-system
 namespace: certificates-system
 
-commonLabels:
-  flux.kub3.uk/organisation: n3tuk
-  flux.kub3.uk/repository: infra-flux
-  flux.kub3.uk/kustomization: cert-manager-crds
-  flux.kub3.uk/name: cert-manager
-  flux.kub3.uk/application: cert-manager
-  flux.kub3.uk/component: certificates
-  flux.kub3.uk/managed-by: kustomization
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/kustomization: certificates
+      flux.kub3.uk/name: cert-manager
+      flux.kub3.uk/application: cert-manager
+      flux.kub3.uk/component: certificates
+      flux.kub3.uk/managed-by: kustomization
 
 resources:
   - cloudflare-secrets.yaml

--- a/flux/cloudflared/kustomization.yaml
+++ b/flux/cloudflared/kustomization.yaml
@@ -6,19 +6,21 @@ metadata:
   namespace: flux-system
 namespace: cloudflared-system
 
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/kustomization: cloudflared
+      flux.kub3.uk/name: cloudflared
+      flux.kub3.uk/application: cloudflared
+      flux.kub3.uk/component: tunnel
+      flux.kub3.uk/managed-by: kustomization
+
 resources:
   - namespace.yaml
   - cloudflared-helm.yaml
   - cloudflared-secrets.yaml
-
-commonLabels:
-  flux.kub3.uk/organisation: n3tuk
-  flux.kub3.uk/repository: infra-flux
-  flux.kub3.uk/kustomization: cloudflared
-  flux.kub3.uk/name: cloudflared
-  flux.kub3.uk/application: cloudflared
-  flux.kub3.uk/component: tunnel
-  flux.kub3.uk/managed-by: kustomization
 
 configMapGenerator:
   - name: helm-cloudflared-values

--- a/flux/cluster/external-dns.yaml
+++ b/flux/cluster/external-dns.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: external-dns
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: baseline
+  path: external-dns
+  dependsOn:
+    - name: sources
+    - name: prometheus-crds
+  interval: 1h
+  retryInterval: 10m
+  prune: true
+
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cert-manager-substitutions

--- a/flux/cluster/kustomization.yaml
+++ b/flux/cluster/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 metadata:
   name: cluster
 namespace: flux-system
+
 resources:
   - sources.yaml
   - custom-resources.yaml
@@ -14,3 +15,4 @@ resources:
   - cloudflared.yaml
   - cert-manager.yaml
   - certificates.yaml
+  - external-dns.yaml

--- a/flux/core-dns/kustomization.yaml
+++ b/flux/core-dns/kustomization.yaml
@@ -5,14 +5,16 @@ metadata:
   name: core-dns
 namespace: kube-system
 
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/kustomization: core-dns
+      flux.kub3.uk/name: core-dns
+      flux.kub3.uk/application: core-dns
+      flux.kub3.uk/component: service-monitor
+      flux.kub3.uk/managed-by: kustomization
+
 resources:
   - service-monitor.yaml
-
-commonLabels:
-  flux.kub3.uk/organisation: n3tuk
-  flux.kub3.uk/repository: infra-flux
-  flux.kub3.uk/kustomization: core-dns
-  flux.kub3.uk/name: core-dns
-  flux.kub3.uk/application: core-dns
-  flux.kub3.uk/component: service-monitor
-  flux.kub3.uk/managed-by: kustomization

--- a/flux/external-dns/cloudflare/cloudflare-helm.yaml
+++ b/flux/external-dns/cloudflare/cloudflare-helm.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: cloudflare
+spec:
+  chart:
+    spec:
+      sourceRef:
+        kind: HelmRepository
+        namespace: flux-system
+        name: external-dns
+      chart: external-dns
+      interval: 5m
+      version: 1.15.0
+  interval: 3h
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  test:
+    enable: true
+  driftDetection:
+    mode: enabled
+
+  valuesFrom:
+    - kind: ConfigMap
+      name: helm-cloudflare-values

--- a/flux/external-dns/cloudflare/cloudflare-secrets.yaml
+++ b/flux/external-dns/cloudflare/cloudflare-secrets.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflare-token
+  labels:
+    app.kubernetes.io/managed-by: Kustomization
+stringData:
+  api-token: ${cloudflare_api_token}

--- a/flux/external-dns/cloudflare/cloudflare-values.yaml
+++ b/flux/external-dns/cloudflare/cloudflare-values.yaml
@@ -1,0 +1,51 @@
+---
+# Enfoce an override on all naming to allow concurrent external-dns services to
+# operate within the same namespace, allowing DNS records to be managed
+# centrally for multiple providers, as needed
+nameOverride: cloudflare
+
+serviceAccount:
+  create: true
+serviceMonitor:
+  enabled: true
+
+logFormat: json
+
+resources:
+  limits: # Don't limit the CPU
+    memory: 128Mi
+  requests:
+    cpu: 10m
+    memory: 64Mi
+
+provider:
+  name: cloudflare
+domainFilters:
+  - kub3.uk
+  - pip3.uk
+  - t3st.uk
+  - sit3.uk
+  - liv3.uk
+
+interval: 15m
+triggerLoopOnEvent: true
+policy: sync
+sources:
+  - ingress
+  - service
+
+registry: txt
+txtOwnerId: ${cluster_name}/external-dns/cloudflare
+txtPrefix: _%{record_type}.
+
+env:
+  - name: CF_API_TOKEN
+    value: file:/etc/cloudflare/api-token
+extraVolumes:
+  - name: cloudflare-token
+    secret:
+      secretName: cloudflare-token
+extraVolumeMounts:
+  - name: cloudflare-token
+    mountPath: /etc/cloudflare
+    readOnly: true

--- a/flux/external-dns/cloudflare/kustomization.yaml
+++ b/flux/external-dns/cloudflare/kustomization.yaml
@@ -6,8 +6,10 @@ metadata:
   namespace: flux-system
 namespace: dns-system
 
-commonLabels:
-  flux.kub3.uk/component: cloudflare
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/component: cloudflare
 
 resources:
   - cloudflare-helm.yaml

--- a/flux/external-dns/cloudflare/kustomization.yaml
+++ b/flux/external-dns/cloudflare/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: external-dns
+  namespace: flux-system
+namespace: dns-system
+
+commonLabels:
+  flux.kub3.uk/component: cloudflare
+
+resources:
+  - cloudflare-helm.yaml
+  - cloudflare-secrets.yaml
+
+configMapGenerator:
+  - name: helm-cloudflare-values
+    files:
+      - values.yaml=cloudflare-values.yaml
+
+configurations:
+  - kustomize-config.yaml

--- a/flux/external-dns/cloudflare/kustomize-config.yaml
+++ b/flux/external-dns/cloudflare/kustomize-config.yaml
@@ -1,0 +1,9 @@
+---
+# Automatically update the reference to the ConfigMap containing the HelmRelease
+# values, forcing the resource to reconcile on changes to the configuration
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/flux/external-dns/kustomization.yaml
+++ b/flux/external-dns/kustomization.yaml
@@ -6,12 +6,15 @@ metadata:
   namespace: flux-system
 namespace: dns-system
 
-commonLabels:
-  flux.kub3.uk/organisation: n3tuk
-  flux.kub3.uk/repository: infra-flux
-  flux.kub3.uk/name: external-dns
-  flux.kub3.uk/kustomization: external-dns
-  flux.kub3.uk/application: external-dns
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/kustomization: external-dns
+      flux.kub3.uk/name: external-dns
+      flux.kub3.uk/application: external-dns
+      flux.kub3.uk/managed-by: kustomization
 
 resources:
   - namespace.yaml

--- a/flux/external-dns/kustomization.yaml
+++ b/flux/external-dns/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: external-dns
+  namespace: flux-system
+namespace: dns-system
+
+commonLabels:
+  flux.kub3.uk/organisation: n3tuk
+  flux.kub3.uk/repository: infra-flux
+  flux.kub3.uk/name: external-dns
+  flux.kub3.uk/kustomization: external-dns
+  flux.kub3.uk/application: external-dns
+
+resources:
+  - namespace.yaml
+  - cloudflare

--- a/flux/external-dns/namespace.yaml
+++ b/flux/external-dns/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dns-system
+  labels:
+    flux.kub3.uk/component: external-dns

--- a/flux/flux/kustomization.yaml
+++ b/flux/flux/kustomization.yaml
@@ -5,18 +5,21 @@ metadata:
   name: flux
   namespace: flux-system
 namespace: flux-system
+
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/kustomization: flux
+      flux.kub3.uk/name: flux
+      flux.kub3.uk/application: flux
+      flux.kub3.uk/component: flux
+      flux.kub3.uk/managed-by: kustomization
+
 resources:
   # Namespace already created during bootstrapping
   - flux-helm.yaml
-
-commonLabels:
-  flux.kub3.uk/organisation: n3tuk
-  flux.kub3.uk/repository: infra-flux
-  flux.kub3.uk/kustomization: flux
-  flux.kub3.uk/name: flux
-  flux.kub3.uk/application: flux
-  flux.kub3.uk/component: flux
-  flux.kub3.uk/managed-by: kustomization
 
 configMapGenerator:
   - name: helm-flux-values

--- a/flux/grafana-crds/kustomization.yaml
+++ b/flux/grafana-crds/kustomization.yaml
@@ -5,14 +5,16 @@ metadata:
   name: grfana-operator
 namespace: grafana-operator
 
-commonLabels:
-  flux.kub3.uk/organisation: n3tuk
-  flux.kub3.uk/repository: infra-flux
-  flux.kub3.uk/kustomization: grafana-crds
-  flux.kub3.uk/name: grafana-operator
-  flux.kub3.uk/application: grafana
-  flux.kub3.uk/component: grafana-operator
-  flux.kub3.uk/managed-by: kustomization
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/kustomization: grafana-crds
+      flux.kub3.uk/name: grafana-operator
+      flux.kub3.uk/application: grafana
+      flux.kub3.uk/component: grafana-operator
+      flux.kub3.uk/managed-by: kustomization
 
 resources:
   - namespace.yaml

--- a/flux/metrics-server/kustomization.yaml
+++ b/flux/metrics-server/kustomization.yaml
@@ -6,17 +6,19 @@ metadata:
   namespace: flux-system
 namespace: kube-system
 
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/kustomization: metrics-server
+      flux.kub3.uk/name: metrics-server
+      flux.kub3.uk/application: metrics-server
+      flux.kub3.uk/component: metrics-server
+      flux.kub3.uk/managed-by: kustomization
+
 resources:
   - metrics-server-helm.yaml
-
-commonLabels:
-  flux.kub3.uk/organisation: n3tuk
-  flux.kub3.uk/repository: infra-flux
-  flux.kub3.uk/kustomization: metrics-server
-  flux.kub3.uk/name: metrics-server
-  flux.kub3.uk/application: metrics-server
-  flux.kub3.uk/component: metrics-server
-  flux.kub3.uk/managed-by: kustomization
 
 configMapGenerator:
   - name: helm-metrics-server-values

--- a/flux/prometheus-crds/kustomization.yaml
+++ b/flux/prometheus-crds/kustomization.yaml
@@ -5,14 +5,16 @@ metadata:
   name: prometheus-operator
 namespace: prometheus-operator
 
-commonLabels:
-  flux.kub3.uk/organisation: n3tuk
-  flux.kub3.uk/repository: infra-flux
-  flux.kub3.uk/kustomization: prometheus-crds
-  flux.kub3.uk/name: prometheus
-  flux.kub3.uk/application: prometheus
-  flux.kub3.uk/component: prometheus-operator
-  flux.kub3.uk/managed-by: kustomization
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/kustomization: prometheus-crds
+      flux.kub3.uk/name: prometheus
+      flux.kub3.uk/application: prometheus
+      flux.kub3.uk/component: prometheus-operator
+      flux.kub3.uk/managed-by: kustomization
 
 resources:
   - namespace.yaml

--- a/flux/proxmox-csi/kustomization.yaml
+++ b/flux/proxmox-csi/kustomization.yaml
@@ -6,19 +6,21 @@ metadata:
   namespace: flux-system
 namespace: proxmox-system
 
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/kustomization: proxmox
+      flux.kub3.uk/name: proxmox
+      flux.kub3.uk/application: proxmox
+      flux.kub3.uk/component: csi
+      flux.kub3.uk/managed-by: kustomization
+
 resources:
   - namespace.yaml
   - proxmox-csi-helm.yaml
   - proxmox-csi-secrets.yaml
-
-commonLabels:
-  flux.kub3.uk/organisation: n3tuk
-  flux.kub3.uk/repository: infra-flux
-  flux.kub3.uk/kustomization: proxmox
-  flux.kub3.uk/name: proxmox
-  flux.kub3.uk/application: proxmox
-  flux.kub3.uk/component: csi
-  flux.kub3.uk/managed-by: kustomization
 
 configMapGenerator:
   - name: helm-proxmox-csi-values

--- a/flux/sources/external-dns.yaml
+++ b/flux/sources/external-dns.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: external-dns
+spec:
+  url: https://kubernetes-sigs.github.io/external-dns/
+  interval: 24h

--- a/flux/sources/kustomization.yaml
+++ b/flux/sources/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 metadata:
   name: sources
 namespace: flux-system
+
 resources:
   - flux-community.yaml
   - proxmox-csi.yaml

--- a/flux/sources/kustomization.yaml
+++ b/flux/sources/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - metrics-server.yaml
   - cloudflare.yaml
   - jetstack.yaml
+  - external-dns.yaml

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -31,6 +31,8 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [cloudflare_api_token.cert_manager](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/api_token) | resource |
+| [cloudflare_api_token.external_dns](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/api_token) | resource |
 | [cloudflare_zero_trust_tunnel_cloudflared.cluster](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_cloudflared) | resource |
 | [cloudflare_zero_trust_tunnel_cloudflared_config.cluster](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_tunnel_cloudflared_config) | resource |
 | [kubernetes_config_map_v1.common_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
@@ -38,9 +40,13 @@ No modules.
 | [kubernetes_config_map_v1.proxmox_csi_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
 | [kubernetes_manifest.flux_system_baseline](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.flux_system_cluster](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_secret_v1.flux_system_cert_manager_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [kubernetes_secret_v1.flux_system_cloudflared_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [kubernetes_secret_v1.flux_system_external_dns_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [kubernetes_secret_v1.proxmox_csi_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [random_password.tunnel](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [cloudflare_api_token_permission_groups.all](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/data-sources/api_token_permission_groups) | data source |
+| [cloudflare_zone.n3tuk](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/data-sources/zone) | data source |
 
 ## Inputs
 

--- a/terraform/external-dns.tf
+++ b/terraform/external-dns.tf
@@ -1,0 +1,38 @@
+resource "cloudflare_api_token" "external_dns" {
+  name = "external-dns@${var.cluster_domain}"
+
+  policy {
+    permission_groups = [
+      data.cloudflare_api_token_permission_groups.all.zone["DNS Write"],
+    ]
+
+    resources = {
+      for zone in data.cloudflare_zone.n3tuk :
+      "com.cloudflare.api.account.zone.${zone.id}" => "*"
+    }
+  }
+
+  condition {
+    request_ip {
+      in = local.cloudflare_ip
+    }
+  }
+}
+
+resource "kubernetes_secret_v1" "flux_system_external_dns_substitutions" {
+  metadata {
+    name      = "external-dns-substitutions"
+    namespace = "flux-system"
+
+    labels = merge(local.kubernetes_labels, {
+      "flux.kub3.uk/name"     = "external-dns"
+      "flux.kub3.uk/instance" = "external-dns"
+    })
+  }
+
+  type = "Opaque"
+
+  data = {
+    cloudflare_api_token = cloudflare_api_token.external_dns.value
+  }
+}


### PR DESCRIPTION
Implement the `external-dns` service with a connection to Cloudflare as a dedicated service for these clusters' standard domains. Also, add support for generating the API tokens needed via Cloudflare using Terraform.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
