### PR TITLE
Implement `internal` and `external` `ingress-nginx` services

### DIFF
--- a/flux/cluster/ingress-nginx.yaml
+++ b/flux/cluster/ingress-nginx.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ingress-nginx
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: baseline
+  path: ingress-nginx
+  dependsOn:
+    - name: sources
+    - name: prometheus-crds
+    - name: cert-manager-crds
+  interval: 1h
+  retryInterval: 10m
+  prune: true
+
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-substitutions

--- a/flux/cluster/kustomization.yaml
+++ b/flux/cluster/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - cert-manager.yaml
   - certificates.yaml
   - external-dns.yaml
+  - ingress-nginx.yaml

--- a/flux/ingress-nginx/certificates.yaml
+++ b/flux/ingress-nginx/certificates.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: self-signed
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ingress-nginx-ca
+  namespace: ingress-nginx
+spec:
+  isCA: true
+  commonName: ingress-nginx Private Certificate Authority
+  subject:
+    organizations:
+      - n3t.uk Lab Environment
+    organizationalUnits:
+      - n3tuk Kubernetes Certificate Authority
+    provinces:
+      - Bridgend
+    localities:
+      - Wales
+    countries:
+      - UK
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: ingress-nginx-root-ca-tls
+  issuerRef:
+    name: self-signed
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+spec:
+  ca:
+    secretName: ingress-nginx-root-ca-tls

--- a/flux/ingress-nginx/external/certificates.yaml
+++ b/flux/ingress-nginx/external/certificates.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: self-signed
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ingress-nginx-ca
+  namespace: ingress-nginx
+spec:
+  isCA: true
+  commonName: ingress-nginx Private Certificate Authority
+  subject:
+    organizations:
+      - n3t.uk Lab Environment
+    organizationalUnits:
+      - n3tuk Kubernetes Certificate Authority
+    provinces:
+      - Bridgend
+    localities:
+      - Wales
+    countries:
+      - UK
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: ingress-nginx-root-ca-tls
+  issuerRef:
+    name: self-signed
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+spec:
+  ca:
+    secretName: ingress-nginx-root-ca-tls

--- a/flux/ingress-nginx/external/external-helm.yaml
+++ b/flux/ingress-nginx/external/external-helm.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: external
+spec:
+  chart:
+    spec:
+      sourceRef:
+        kind: HelmRepository
+        namespace: flux-system
+        name: ingress-nginx
+      chart: ingress-nginx
+      interval: 5m
+      version: 4.11.3
+  interval: 3h
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  driftDetection:
+    mode: enabled
+
+  valuesFrom:
+    - kind: ConfigMap
+      name: helm-external-values

--- a/flux/ingress-nginx/external/external-values.yaml
+++ b/flux/ingress-nginx/external/external-values.yaml
@@ -1,0 +1,107 @@
+---
+fullnameOverride: external
+
+controller:
+  image:
+    readOnlyRootFilesystem: false
+  ingressClassResource:
+    name: external
+    default: false
+  ingressClass: external
+
+  kind: Deployment
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+
+  replicaCount: 3
+  minAvailable: 2
+
+  resources:
+    limits: # Don't limit the CPU
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: ingress-nginx
+          app.kubernetes.io/instance: external
+          app.kubernetes.io/component: controller
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: ingress-nginx
+          app.kubernetes.io/instance: external
+          app.kubernetes.io/component: controller
+
+  service:
+    enabled: true
+    external:
+      enabled: true
+    type: LoadBalancer
+    externalTrafficPolicy: Local
+    sessionAffinity: None
+
+  opentelemetry:
+    enabled: false
+
+  # admissionWebhooks:
+  #   certManager:
+  #     enabled: true
+  #     rootCert:
+  #       duration: 43800h # 5y
+  #     admissionCert:
+  #       duration: 2184h # 13w
+  #       issuerRef:
+  #         kind: ClusterIssuer
+  #         name: ingress-nginx
+
+  metrics:
+    port: 10254
+    portName: metrics
+    enabled: true
+    serviceMonitor:
+      enabled: true
+
+defaultBackend:
+  enabled: true
+  name: default-backend
+
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+
+  replicaCount: 2
+  minAvailable: 1
+  resources:
+    limits:
+      memory: 32Mi
+    requests:
+      cpu: 10m
+      memory: 16Mi
+
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: ingress-nginx
+          app.kubernetes.io/component: default-backend
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: ingress-nginx
+          app.kubernetes.io/component: default-backend

--- a/flux/ingress-nginx/external/kustomization.yaml
+++ b/flux/ingress-nginx/external/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: external
+  namespace: flux-system
+
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/component: external
+
+resources:
+  - external-helm.yaml
+
+configMapGenerator:
+  - name: helm-external-values
+    files:
+      - values.yaml=external-values.yaml
+
+configurations:
+  - kustomize-config.yaml

--- a/flux/ingress-nginx/external/kustomize-config.yaml
+++ b/flux/ingress-nginx/external/kustomize-config.yaml
@@ -1,0 +1,9 @@
+---
+# Automatically update the reference to the ConfigMap containing the HelmRelease
+# values, forcing the resource to reconcile on changes to the configuration
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/flux/ingress-nginx/external/namespace.yaml
+++ b/flux/ingress-nginx/external/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-system
+  labels:
+    app.kubernetes.io/managed-by: Kustomization
+    app.kubernetes.io/name: ingress-nginx

--- a/flux/ingress-nginx/internal/certificates.yaml
+++ b/flux/ingress-nginx/internal/certificates.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: self-signed
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ingress-nginx-ca
+  namespace: ingress-nginx
+spec:
+  isCA: true
+  commonName: ingress-nginx Private Certificate Authority
+  subject:
+    organizations:
+      - n3t.uk Lab Environment
+    organizationalUnits:
+      - n3tuk Kubernetes Certificate Authority
+    provinces:
+      - Bridgend
+    localities:
+      - Wales
+    countries:
+      - UK
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: ingress-nginx-root-ca-tls
+  issuerRef:
+    name: self-signed
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+spec:
+  ca:
+    secretName: ingress-nginx-root-ca-tls

--- a/flux/ingress-nginx/internal/internal-helm.yaml
+++ b/flux/ingress-nginx/internal/internal-helm.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: internal
+spec:
+  chart:
+    spec:
+      sourceRef:
+        kind: HelmRepository
+        namespace: flux-system
+        name: ingress-nginx
+      chart: ingress-nginx
+      interval: 5m
+      version: 4.11.3
+  interval: 3h
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  driftDetection:
+    mode: enabled
+
+  valuesFrom:
+    - kind: ConfigMap
+      name: helm-internal-values

--- a/flux/ingress-nginx/internal/internal-values.yaml
+++ b/flux/ingress-nginx/internal/internal-values.yaml
@@ -1,0 +1,111 @@
+---
+fullnameOverride: internal
+
+controller:
+  image:
+    # unexpected error storing fake SSL Cert: could not create PEM certificate
+    # file /etc/ingress-controller/ssl/default-fake-certificate.pem: open
+    # /etc/ingress-controller/ssl/default-fake-certificate.pem: read-only file
+    # system
+    readOnlyRootFilesystem: false
+  ingressClassResource:
+    name: internal
+    default: true
+  ingressClass: internal
+
+  kind: Deployment
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+
+  replicaCount: 3
+  minAvailable: 2
+
+  resources:
+    limits: # Don't limit the CPU
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: ingress-nginx
+          app.kubernetes.io/instance: internal
+          app.kubernetes.io/component: controller
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: ingress-nginx
+          app.kubernetes.io/instance: internal
+          app.kubernetes.io/component: controller
+
+  service:
+    enabled: true
+    external:
+      enabled: true
+    type: LoadBalancer
+    externalTrafficPolicy: Local
+    sessionAffinity: None
+
+  opentelemetry:
+    enabled: false
+
+  # admissionWebhooks:
+  #   certManager:
+  #     enabled: true
+  #     rootCert:
+  #       duration: 43800h # 5y
+  #     admissionCert:
+  #       duration: 2184h # 13w
+  #       issuerRef:
+  #         kind: ClusterIssuer
+  #         name: ingress-nginx
+
+  metrics:
+    port: 10254
+    portName: metrics
+    enabled: true
+    serviceMonitor:
+      enabled: true
+
+defaultBackend:
+  enabled: true
+  name: default-backend
+
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+
+  replicaCount: 2
+  minAvailable: 1
+  resources:
+    limits:
+      memory: 32Mi
+    requests:
+      cpu: 10m
+      memory: 16Mi
+
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: ingress-nginx
+          app.kubernetes.io/component: default-backend
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: ingress-nginx
+          app.kubernetes.io/component: default-backend

--- a/flux/ingress-nginx/internal/kustomization.yaml
+++ b/flux/ingress-nginx/internal/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: internal
+  namespace: flux-system
+
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/component: internal
+
+resources:
+  - internal-helm.yaml
+
+configMapGenerator:
+  - name: helm-internal-values
+    files:
+      - values.yaml=internal-values.yaml
+
+configurations:
+  - kustomize-config.yaml

--- a/flux/ingress-nginx/internal/kustomize-config.yaml
+++ b/flux/ingress-nginx/internal/kustomize-config.yaml
@@ -1,0 +1,9 @@
+---
+# Automatically update the reference to the ConfigMap containing the HelmRelease
+# values, forcing the resource to reconcile on changes to the configuration
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/flux/ingress-nginx/internal/namespace.yaml
+++ b/flux/ingress-nginx/internal/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-system
+  labels:
+    app.kubernetes.io/managed-by: Kustomization
+    app.kubernetes.io/name: ingress-nginx

--- a/flux/ingress-nginx/kustomization.yaml
+++ b/flux/ingress-nginx/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: ingress-nginx
+  namespace: flux-system
+namespace: ingress-system
+
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/kustomization: ingress-nginx
+      flux.kub3.uk/name: ingress-nginx
+      flux.kub3.uk/application: ingress-nginx
+      flux.kub3.uk/managed-by: kustomization
+
+resources:
+  - namespace.yaml
+  - certificates.yaml
+  - internal
+  - external

--- a/flux/ingress-nginx/namespace.yaml
+++ b/flux/ingress-nginx/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-system
+  labels:
+    app.kubernetes.io/managed-by: Kustomization
+    app.kubernetes.io/name: ingress-nginx

--- a/flux/sources/ingress-nginx.yaml
+++ b/flux/sources/ingress-nginx.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+spec:
+  url: https://kubernetes.github.io/ingress-nginx
+  interval: 24h

--- a/flux/sources/kustomization.yaml
+++ b/flux/sources/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - cloudflare.yaml
   - jetstack.yaml
   - external-dns.yaml
+  - ingress-nginx.yaml


### PR DESCRIPTION
Implement two separate deployments of the `ingress-nginx` service for applications which require ingress form `internal` locations, and those that require it from `external` locations (i.e. via Cloudflare Tunnels). Each is a separate `Kustomization` and `HelmRelease` deployment, ensuring that traffic cannot leak (i.e. sending an `internal` host via an `external` `Ingress`).

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
