### PR TITLE
Implement the Prometheus service for metrics monitoring

### DIFF
--- a/flux/cluster/kustomization.yaml
+++ b/flux/cluster/kustomization.yaml
@@ -18,3 +18,4 @@ resources:
   - external-dns.yaml
   - ingress-nginx.yaml
   - metallb.yaml
+  - prometheus.yaml

--- a/flux/cluster/kustomization.yaml
+++ b/flux/cluster/kustomization.yaml
@@ -18,4 +18,5 @@ resources:
   - external-dns.yaml
   - ingress-nginx.yaml
   - metallb.yaml
+  - routing.yaml
   - prometheus.yaml

--- a/flux/cluster/prometheus.yaml
+++ b/flux/cluster/prometheus.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prometheus
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: baseline
+  path: prometheus
+  dependsOn:
+    - name: prometheus-crds
+    - name: cert-manager-crds
+    - name: proxmox-csi
+  interval: 1h
+  retryInterval: 10m
+  prune: true
+
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-substitutions

--- a/flux/metallb/kustomization.yaml
+++ b/flux/metallb/kustomization.yaml
@@ -25,3 +25,6 @@ configMapGenerator:
   - name: helm-metallb-values
     files:
       - values.yaml=metallb-values.yaml
+
+configurations:
+  - kustomize-config.yaml

--- a/flux/prometheus/ingress.yaml
+++ b/flux/prometheus/ingress.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prometheus
+  namespace: prometheus-system
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-cloudflare-production
+  labels:
+    prometheus: metrics
+spec:
+  ingressClassName: internal
+  rules:
+    - host: prometheus.${cluster_domain}
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: prometheus
+                port:
+                  number: 9090
+  tls:
+    - hosts:
+        - prometheus.${cluster_domain}
+      secretName: ingress-prometheus-tls

--- a/flux/prometheus/kustomization.yaml
+++ b/flux/prometheus/kustomization.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: prometheus-metrics
+  namespace: flux-system
+namespace: prometheus-metrics
+
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/kustomization: prometheus
+      flux.kub3.uk/name: prometheus
+      flux.kub3.uk/application: prometheus
+      flux.kub3.uk/component: metrics
+      flux.kub3.uk/managed-by: kustomization
+
+resources:
+  - namespace.yaml
+  - service-account.yaml
+  - prometheus.yaml
+  - service.yaml
+  - service-monitor.yaml
+  - ingress.yaml

--- a/flux/prometheus/namespace.yaml
+++ b/flux/prometheus/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prometheus-metrics
+  labels:
+    app.kubernetes.io/managed-by: Kustomization
+    app.kubernetes.io/name: prometheus

--- a/flux/prometheus/prometheus.yaml
+++ b/flux/prometheus/prometheus.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: metrics
+  labels:
+    prometheus: metrics
+spec:
+  image: quay.io/prometheus/prometheus:v3.0.0
+  version: v3.0.0
+
+  externalUrl: https://prometheus.${cluster_domain}/
+
+  nodeSelector:
+    kubernetes.io/os: linux
+  replicas: 2
+  shards: 1
+
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          prometheus: metrics
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          prometheus: metrics
+
+  enableFeatures:
+    - memory-snapshot-on-shutdown
+
+  serviceAccountName: prometheus
+
+  retention: 360h
+  retentionSize: 112GiB
+  disableCompaction: true
+  storage:
+    volumeClaimTemplate:
+      spec:
+        storageClassName: proxmox-rbd-ext4
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 128Gi
+
+  resources:
+    limits: # Don't limit the CPU
+      memory: 1024Mi
+    requests:
+      cpu: 500m
+      memory: 256Mi
+
+  logFormat: json
+
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
+
+  podMonitorSelector: {}
+  podMonitorNamespaceSelector: {}
+  serviceMonitorSelector: {}
+  serviceMonitorNamespaceSelector: {}
+
+  ruleSelector:
+    matchLabels:
+      alertmanager: metrics
+
+  externalLabels:
+    environment: ${environment}
+    cluster: ${cluster_domain}
+    location: bridgend
+
+  alerting:
+    alertmanagers:
+      - namespace: prometheus-metrics
+        name: alertmanager-operated
+        port: web

--- a/flux/prometheus/service-account.yaml
+++ b/flux/prometheus/service-account.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  labels:
+    prometheus: metrics
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-metrics-prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-metrics
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: prometheus-metrics
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-metrics
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get

--- a/flux/prometheus/service-monitor.yaml
+++ b/flux/prometheus/service-monitor.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prometheus
+  labels:
+    prometheus: metrics
+spec:
+  endpoints:
+    - interval: 30s
+      port: web
+  selector:
+    matchLabels:
+      prometheus: metrics

--- a/flux/prometheus/service.yaml
+++ b/flux/prometheus/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  labels:
+    prometheus: metrics
+spec:
+  type: ClusterIP
+  ports:
+    - name: web
+      port: 9090
+      protocol: TCP
+      targetPort: web
+  selector:
+    prometheus: metrics
+  sessionAffinity: ClientIP

--- a/flux/sources/kustomization.yaml
+++ b/flux/sources/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - external-dns.yaml
   - ingress-nginx.yaml
   - metallb.yaml
+  - prometheus-community.yaml


### PR DESCRIPTION
Implement the Prometheus service to provide general monitoring of cluster metrics using the `prometheus-operator` `Prometheus` resource, and associated resources, such as `Service` and `Ingress`.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
