### PR TITLE
Implement Alertmanager service for Prometheus

### DIFF
--- a/flux/alertmanager/alertmanager.yaml
+++ b/flux/alertmanager/alertmanager.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Alertmanager
+metadata:
+  name: metrics
+  labels:
+    alertmanager: metrics
+spec:
+  image: quay.io/prometheus/alertmanager:v0.27.0
+  version: v0.27.0
+
+  externalUrl: https://alerts.${cluster_domain}/
+
+  alertmanagerConfigSelector:
+    matchLabels:
+      alertmanager: metrics
+  alertmanagerConfigMatcherStrategy:
+    type: None
+  configMaps:
+    - alertmanager-templates
+
+  nodeSelector:
+    kubernetes.io/os: linux
+  replicas: 2
+  # Pods initiate a pull/push sync every sixty seconds, so ensure a Pod is
+  # running successfully for at least 90s before marking it as Ready to ensure
+  # that new Pods synchronise data with old ones on roll-out
+  # minReadySeconds: 90
+
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          alertmanager: metrics
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          alertmanager: metrics
+
+  storage:
+    volumeClaimTemplate:
+      spec:
+        storageClassName: proxmox-rbd-ext4
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi
+
+  resources:
+    limits: # Don't limit the CPU
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 32Mi
+
+  logFormat: json
+  logLevel: debug
+
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault

--- a/flux/alertmanager/common.tmpl
+++ b/flux/alertmanager/common.tmpl
@@ -1,0 +1,102 @@
+{{ define "__text_alert_list" }}{{ range . }}Labels:
+{{ range .Labels.SortedPairs }} - {{ .Name }} = {{ .Value }}
+{{ end }}Annotations:
+{{ range .Annotations.SortedPairs }} - {{ .Name }} = {{ .Value }}
+{{ end }}Source: {{ .GeneratorURL }}
+{{ end }}{{ end }}
+
+{{ define "custom_single_alert_message" }}
+  {{- "\n" }}
+  {{- range .Firing }}
+    {{- .Annotations.description }}
+  {{- end }}
+  {{- range .Resolved }}
+    {{- .Annotations.description }}
+  {{- end }}
+{{- end }}
+
+
+{{ define "custom_multiple_alerts_message" }}
+  {{- if gt (len .Firing) 0 }}
+  {{- "\n*Alerts Firing:*" }}
+    {{- range .Firing }}
+      {{- "\n  -" }} {{ .Annotations.description }}
+    {{- end }}
+  {{- end }}
+  {{- if gt (len .Resolved) 0 }}
+  {{- "\n*Alerts Resolved:*" }}
+    {{- range .Resolved }}
+      {{- "\n  - " }}{{ .Annotations.description }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{ define "custom_slack_message" }}
+  {{- if .CommonAnnotations.summary }}
+    {{- .CommonAnnotations.summary }}
+  {{- end }}
+  {{ template "__alert_severity" . }}
+  {{- if or (and (eq (len .Alerts.Firing) 1) (eq (len .Alerts.Resolved) 0)) (and (eq (len .Alerts.Firing) 0) (eq (len .Alerts.Resolved) 1)) }}
+    {{- template "custom_single_alert_message" .Alerts }}
+  {{- else }}
+    {{- template "custom_multiple_alerts_message" .Alerts }}
+  {{- end }}
+{{- end }}
+
+# This builds the silence URL.  We exclude the alertname in the range
+# to avoid the issue of having trailing comma separator (%2C) at the end
+# of the generated URL
+{{ define "__alert_silence_link" -}}
+    {{ .ExternalURL }}/#/silences/new?filter=%7B
+    {{- range .CommonLabels.SortedPairs -}}
+        {{- if ne .Name "alertname" -}}
+            {{- .Name }}%3D"{{- .Value -}}"%2C%20
+        {{- end -}}
+    {{- end -}}
+    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+{{- end }}
+
+# This builds the run book URL.
+{{ define "__runbook_link" -}}
+  {{- "https://confluence.mot-solutions.com/display/AWARE" }}
+  {{- if .CommonAnnotations.ava_runbook }}
+    {{- "/" }}{{ .CommonAnnotations.ava_runbook | toLower }}
+  {{- else }}
+    {{- "/Runbooks#" }}{{ .CommonLabels.alertname | toLower }}
+  {{- end }}
+{{- end }}
+
+# This builds the Thanos URL.
+{{ define "__thanos_link" -}}
+  {{- reReplaceAll "https://.*/graph" "https://thanos.platform.vaion.com/graph" ( index
+.Alerts 0 ).GeneratorURL }}
+
+{{- end }}
+
+# Allow indication of severity
+{{ define "__alert_severity" -}}
+    {{ if ne .Status "firing" -}}
+    {{- else if eq .CommonLabels.severity "critical" -}}
+    *Severity:* Critical
+    {{- else if eq .CommonLabels.severity "warning" -}}
+    *Severity:* Warning
+    {{- else if eq .CommonLabels.severity "info" -}}
+    *Severity:* Info
+    {{- else -}}
+    *Severity:* :question: {{ .CommonLabels.severity }}
+    {{- end }}
+{{- end }}
+
+{{ define "custom_color" -}}
+    {{ if eq .Status "firing" -}}
+        {{ if eq .CommonLabels.severity "warning" -}}
+            warning
+        {{- else if eq .CommonLabels.severity "critical" -}}
+            danger
+        {{- else -}}
+            #439FE0
+        {{- end -}}
+    {{ else -}}
+    good
+    {{- end }}
+{{- end }}

--- a/flux/alertmanager/config.yaml
+++ b/flux/alertmanager/config.yaml
@@ -1,0 +1,146 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-metrics
+  labels:
+    alertmanager: metrics
+type: Opaque
+stringData:
+  alertmanager.yaml: |
+    ---
+    # Set a default, empty configuration which can be expended by the
+    # AlertmanagerConfig resources deployed on the Kubernetes Cluster
+    global:
+      resolve_timeout: 1m
+      pagerduty_url: https://events.eu.pagerduty.com/v2/enqueue
+    templates:
+      - /etc/alertmanager/configmaps/alertmanager-templates/*.tmpl
+    route:
+      group_by:
+        - cluster
+        - namespace
+        - alertname
+      group_interval: 3m
+      group_wait: 15s
+      receiver: empty
+    receivers:
+      - name: empty
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: slack
+  labels:
+    alertmanager: metrics
+spec:
+  route:
+    receiver: slack
+    matchers:
+      - name: slack_channel
+        matchType: =~
+        value: ^#[a-z0-9._-]+$
+    repeatInterval: 24h
+    continue: true
+
+  receivers:
+    - name: slack
+      slackConfigs:
+        - apiURL:
+            name: slack-webhooks
+            key: alerts
+          httpConfig: {}
+          channel: '#alerts'
+          sendResolved: true
+          shortFields: false
+          iconEmoji: ':alertmanager:'
+          iconURL: https://alerts.p.kub3.uk/
+          color: >-
+            {{ template "slack_color" . }}
+          username: >-
+            {{ template "slack_username" . }}
+          title: >-
+            {{ template "slack_summary" . }}
+          titleLink: >-
+            {{ template "slack_link" . }}
+          text: |
+            {{ template "slack_description" . }}
+          footer: |
+            {{ template "slack_footer" . }}
+          fallback: >-
+            {{ template "slack_fallback" . }}
+          fields: []
+          actions:
+            - text: Runbook
+              type: button
+              url: >-
+                {{ (index .Alerts 0).Annotations.runbook_url }}
+            - text: Query
+              type: button
+              url: >-
+                {{ (index .Alerts 0).GeneratorURL }}
+            - text: Dashboard
+              type: button
+              url: >-
+                {{ (index .Alerts 0).Annotations.dashboard }}
+            - text: Silence
+              type: button
+              url: >-
+                {{ template "__alert_silence_link" . }}
+          linkNames: false
+          mrkdwnIn:
+            - title
+            - text
+            - footer
+            - fallback
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: pagerduty
+  labels:
+    alertmanager: metrics
+spec:
+  route:
+    receiver: pagerduty
+    matchers:
+      - name: pagerduty_service
+        matchType: =~
+        value: ^[a-z0-9._-]+$
+    repeatInterval: 1h
+    continue: true
+
+  receivers:
+    - name: pagerduty
+      pagerdutyConfigs:
+        - serviceKey:
+            name: pagerduty-keys
+            key: service-key
+          sendResolved: true
+          client: >-
+            {{ template "pagerduty_client" . }}
+          clientURL: >-
+            {{ template "pagerduty_client_url" . }}
+          description: >-
+            {{ template "pagerduty_description" . }}
+          severity: error
+          source: client
+          details: []
+          pagerDutyLinkConfigs:
+            - alt: Runbooks
+              href: >-
+                {{ .CommonAnnotations.runbook }}
+            - alt: Dashboard
+              href: >-
+                {{ .CommonAnnotations.dashboard }}
+            - alt: Prometheus
+              href: >-
+                {{ (index .Alerts 0).GeneratorURL }}
+            - alt: Alertmanager
+              href: https://alerts.p.kub3.uk/
+            - alt: Silence
+              href: >-
+                {{ template "__alert_silence_link" . }}
+          component: cluster-production
+          # group: <tmpl_string>
+          # class: <tmpl_string>

--- a/flux/alertmanager/ingress.yaml
+++ b/flux/alertmanager/ingress.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: alertmanager
+  namespace: prometheus-system
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-cloudflare-production
+  labels:
+    prometheus: metrics
+spec:
+  ingressClassName: internal
+  rules:
+    - host: alerts.${cluster_domain}
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: alertmanager
+                port:
+                  number: 9093
+  tls:
+    - hosts:
+        - alerts.${cluster_domain}
+      secretName: ingress-alertmanager-tls

--- a/flux/alertmanager/kustomization.yaml
+++ b/flux/alertmanager/kustomization.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: alertmanager-metrics
+  namespace: flux-system
+namespace: prometheus-metrics
+
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/kustomization: alertmanager
+      flux.kub3.uk/name: prometheus
+      flux.kub3.uk/application: alertmanager
+      flux.kub3.uk/component: metrics
+      flux.kub3.uk/managed-by: kustomization
+
+resources:
+  - alertmanager.yaml
+  - config.yaml
+  - service.yaml
+  - service-monitor.yaml
+  - ingress.yaml
+
+configMapGenerator:
+  - name: alertmanager-templates
+    options:
+      # Kustomize transformers cannot target items in lists for prefix and
+      # suffix changes currently, so disable random suffixes on the ConfigMap
+      #   https://github.com/kubernetes-sigs/kustomize/issues/4884
+      disableNameSuffixHash: true
+    files:
+      - common.tmpl=common.tmpl
+      - slack.tmpl=slack.tmpl
+      - pagerduty.tmpl=pagerduty.tmpl

--- a/flux/alertmanager/namespace.yaml
+++ b/flux/alertmanager/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prometheus-metrics
+  labels:
+    app.kubernetes.io/managed-by: Kustomization
+    app.kubernetes.io/name: prometheus

--- a/flux/alertmanager/pagerduty.tmpl
+++ b/flux/alertmanager/pagerduty.tmpl
@@ -1,0 +1,19 @@
+{{  define "pagerduty_client" -}}
+alertmanager ({{ .GroupLabels.cluster }})
+{{- end }}
+
+{{  define "pagerduty_client_url" -}}
+{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver | urlquery }}
+{{- end }}
+
+{{  define "pagerduty_description" -}}
+{{-   if .CommonAnnotations.description -}}
+{{ .CommonAnnotations.description }}
+{{-   else -}}
+The alert `{{ .GroupLabels.alertname }}` has fired, but has no description.
+{{-   end -}}
+{{- end }}
+
+{{ define "pagerduty_instances" }}
+{{ template "__text_alert_list" . }}
+{{ end }}

--- a/flux/alertmanager/service-monitor.yaml
+++ b/flux/alertmanager/service-monitor.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: alertmanager
+  labels:
+    alertmanager: metrics
+spec:
+  endpoints:
+    - interval: 30s
+      port: web
+  selector:
+    matchLabels:
+      alertmanager: metrics

--- a/flux/alertmanager/service.yaml
+++ b/flux/alertmanager/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager
+  labels:
+    alertmanager: metrics
+spec:
+  type: ClusterIP
+  ports:
+    - name: web
+      port: 9093
+      protocol: TCP
+      targetPort: web
+  selector:
+    alertmanager: metrics
+  sessionAffinity: ClientIP

--- a/flux/alertmanager/slack.tmpl
+++ b/flux/alertmanager/slack.tmpl
@@ -1,0 +1,50 @@
+{{  define "slack_username" -}}
+alertmanager ({{ .CommonLabels.cluster }})
+{{- end }}
+
+{{  define "slack_summary" -}}
+{{-   if .CommonAnnotations.summary }}{{ .CommonAnnotations.summary }}
+{{-   else }}{{ .GroupLabels.alertname }}
+{{-   end }}
+{{- end }}
+
+{{  define "slack_link" -}}
+{{-   if .CommonAnnotations.link }}{{ .CommonAnnotations.link }}
+{{-   else if .CommonAnnotations.dashboard }}{{ .CommonAnnotations.dashboard }}
+{{-   else if .CommonAnnotations.runbook }}{{ .CommonAnnotations.runbook }}
+{{-   else }}{{ (index .Alerts 0).GeneratorURL }}
+{{-   end }}
+{{- end }}
+
+{{  define "slack_description" -}}
+{{-   if .CommonAnnotations.description -}}
+{{ .CommonAnnotations.description }}
+{{-   else -}}
+The alert `{{ .GroupLabels.alertname }}` has fired, but has no description.
+{{-   end -}}
+{{- end }}
+
+{{  define "slack_fallback" -}}
+{{  template "slack_summary" . }} | {{ template "slack_link" . }}
+{{- end }}
+
+{{  define "slack_footer" -}}
+Alert Name: {{ .GroupLabels.alertname }}
+Severity: {{ .CommonLabels.severity }}
+Cluster: {{ .GroupLabels.cluster }}
+{{-   if .CommonLabels.pod }}
+Pod: {{ .GroupLabels.namespace }}/{{ .CommonLabels.pod }}
+{{-   else }}
+Namespace: {{ .GroupLabels.namespace }}
+{{-   end }}
+{{- end }}
+
+{{  define "slack_color" }}
+{{-   if eq .Status "firing" -}}
+{{-     if eq .CommonLabels.severity "critical" -}} danger
+{{-     else if eq .CommonLabels.severity "warning" -}} warning
+{{-     else -}} #439FE0
+{{-     end -}}
+{{-   else -}} good
+{{- end -}}
+{{- end }}

--- a/flux/cluster/alertmanager.yaml
+++ b/flux/cluster/alertmanager.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: alertmanager
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: baseline
+  path: alertmanager
+  dependsOn:
+    - name: prometheus
+    - name: cert-manager-crds
+    - name: proxmox-csi
+  interval: 1h
+  retryInterval: 10m
+  prune: true
+
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-substitutions

--- a/flux/cluster/kustomization.yaml
+++ b/flux/cluster/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
   - metallb.yaml
   - routing.yaml
   - prometheus.yaml
+  - alertmanager.yaml

--- a/flux/prometheus/namespace.yaml
+++ b/flux/prometheus/namespace.yaml
@@ -3,6 +3,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: prometheus-metrics
-  labels:
-    app.kubernetes.io/managed-by: Kustomization
-    app.kubernetes.io/name: prometheus


### PR DESCRIPTION
Implement the Alertmanager service as part of the Prometheus stack, running in a highly-available configuration on the cluster, and standardised with templates for Slack and Pagerduty.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
