### PR TITLE
Implement `kube-state-metrics` and `node-exporter` for Prometheus

### DIFF
--- a/flux/cluster/kube-state-metrics.yaml
+++ b/flux/cluster/kube-state-metrics.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kube-state-metrics
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: baseline
+  path: kube-state-metrics
+  dependsOn:
+    - name: sources
+    - name: prometheus-crds
+  interval: 1h
+  retryInterval: 10m
+  prune: true
+
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-substitutions

--- a/flux/cluster/kustomization.yaml
+++ b/flux/cluster/kustomization.yaml
@@ -21,3 +21,5 @@ resources:
   - routing.yaml
   - prometheus.yaml
   - alertmanager.yaml
+  - node-exporter.yaml
+  - kube-state-metrics.yaml

--- a/flux/cluster/node-exporter.yaml
+++ b/flux/cluster/node-exporter.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: node-exporter
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: baseline
+  path: node-exporter
+  dependsOn:
+    - name: sources
+    - name: prometheus-crds
+  interval: 1h
+  retryInterval: 10m
+  prune: true
+
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-substitutions

--- a/flux/kube-state-metrics/kube-state-metrics-helm.yaml
+++ b/flux/kube-state-metrics/kube-state-metrics-helm.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kube-state-metrics
+spec:
+  chart:
+    spec:
+      sourceRef:
+        kind: HelmRepository
+        namespace: flux-system
+        name: prometheus-community
+      chart: kube-state-metrics
+      interval: 5m
+      version: 5.26.0
+  interval: 3h
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  test:
+    enable: true
+  driftDetection:
+    mode: enabled
+
+  valuesFrom:
+    - kind: ConfigMap
+      name: helm-kube-state-metrics-values

--- a/flux/kube-state-metrics/kube-state-metrics-values.yaml
+++ b/flux/kube-state-metrics/kube-state-metrics-values.yaml
@@ -1,0 +1,21 @@
+---
+replicas: 1
+
+prometheusScrape: true
+prometheus:
+  monitor:
+    enabled: true
+
+rbac:
+  create: true
+  useClusterRole: true
+
+networkPolicy:
+  enabled: false
+
+resources:
+  limits: # Don't limit the CPU
+    memory: 64Mi
+  requests:
+    cpu: 10m
+    memory: 32Mi

--- a/flux/kube-state-metrics/kustomization.yaml
+++ b/flux/kube-state-metrics/kustomization.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: kube-state-metrics
+  namespace: flux-system
+namespace: kube-system
+
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/kustomization: kube-state-metrics
+      flux.kub3.uk/name: prometheus
+      flux.kub3.uk/application: kube-state-metrics
+      flux.kub3.uk/component: metrics
+      flux.kub3.uk/managed-by: kustomization
+
+resources:
+  - kube-state-metrics-helm.yaml
+  - service-monitors.yaml
+
+configMapGenerator:
+  - name: helm-kube-state-metrics-values
+    files:
+      - values.yaml=kube-state-metrics-values.yaml
+
+configurations:
+  - kustomize-config.yaml

--- a/flux/kube-state-metrics/kustomize-config.yaml
+++ b/flux/kube-state-metrics/kustomize-config.yaml
@@ -1,0 +1,9 @@
+---
+# Automatically update the reference to the ConfigMap containing the HelmRelease
+# values, forcing the resource to reconcile on changes to the configuration
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/flux/kube-state-metrics/service-monitors.yaml
+++ b/flux/kube-state-metrics/service-monitors.yaml
@@ -1,0 +1,120 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubelet
+spec:
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubelet
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: scheduler_(e2e_scheduling_latency_microseconds|scheduling_algorithm_predicate_evaluation|scheduling_algorithm_priority_evaluation|scheduling_algorithm_preemption_evaluation|scheduling_algorithm_latency_microseconds|binding_latency_microseconds|scheduling_latency_seconds)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs|longrunning_gauge|registered_watchers|storage_db_total_size_in_bytes|flowcontrol_request_concurrency_limit|flowcontrol_request_concurrency_in_use)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: kubelet_docker_(operations|operations_latency_microseconds|operations_errors|operations_timeout)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: reflector_(items_per_list|items_per_watch|list_duration_seconds|lists_total|short_watches_total|watch_duration_seconds|watches_total)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|object_counts|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: transformation_(transformation_latencies_microseconds|failures_total)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: (admission_quota_controller_adds|admission_quota_controller_depth|admission_quota_controller_longest_running_processor_microseconds|admission_quota_controller_queue_latency|admission_quota_controller_unfinished_work_seconds|admission_quota_controller_work_duration|APIServiceOpenAPIAggregationControllerQueue1_adds|APIServiceOpenAPIAggregationControllerQueue1_depth|APIServiceOpenAPIAggregationControllerQueue1_longest_running_processor_microseconds|APIServiceOpenAPIAggregationControllerQueue1_queue_latency|APIServiceOpenAPIAggregationControllerQueue1_retries|APIServiceOpenAPIAggregationControllerQueue1_unfinished_work_seconds|APIServiceOpenAPIAggregationControllerQueue1_work_duration|APIServiceRegistrationController_adds|APIServiceRegistrationController_depth|APIServiceRegistrationController_longest_running_processor_microseconds|APIServiceRegistrationController_queue_latency|APIServiceRegistrationController_retries|APIServiceRegistrationController_unfinished_work_seconds|APIServiceRegistrationController_work_duration|autoregister_adds|autoregister_depth|autoregister_longest_running_processor_microseconds|autoregister_queue_latency|autoregister_retries|autoregister_unfinished_work_seconds|autoregister_work_duration|AvailableConditionController_adds|AvailableConditionController_depth|AvailableConditionController_longest_running_processor_microseconds|AvailableConditionController_queue_latency|AvailableConditionController_retries|AvailableConditionController_unfinished_work_seconds|AvailableConditionController_work_duration|crd_autoregistration_controller_adds|crd_autoregistration_controller_depth|crd_autoregistration_controller_longest_running_processor_microseconds|crd_autoregistration_controller_queue_latency|crd_autoregistration_controller_retries|crd_autoregistration_controller_unfinished_work_seconds|crd_autoregistration_controller_work_duration|crdEstablishing_adds|crdEstablishing_depth|crdEstablishing_longest_running_processor_microseconds|crdEstablishing_queue_latency|crdEstablishing_retries|crdEstablishing_unfinished_work_seconds|crdEstablishing_work_duration|crd_finalizer_adds|crd_finalizer_depth|crd_finalizer_longest_running_processor_microseconds|crd_finalizer_queue_latency|crd_finalizer_retries|crd_finalizer_unfinished_work_seconds|crd_finalizer_work_duration|crd_naming_condition_controller_adds|crd_naming_condition_controller_depth|crd_naming_condition_controller_longest_running_processor_microseconds|crd_naming_condition_controller_queue_latency|crd_naming_condition_controller_retries|crd_naming_condition_controller_unfinished_work_seconds|crd_naming_condition_controller_work_duration|crd_openapi_controller_adds|crd_openapi_controller_depth|crd_openapi_controller_longest_running_processor_microseconds|crd_openapi_controller_queue_latency|crd_openapi_controller_retries|crd_openapi_controller_unfinished_work_seconds|crd_openapi_controller_work_duration|DiscoveryController_adds|DiscoveryController_depth|DiscoveryController_longest_running_processor_microseconds|DiscoveryController_queue_latency|DiscoveryController_retries|DiscoveryController_unfinished_work_seconds|DiscoveryController_work_duration|kubeproxy_sync_proxy_rules_latency_microseconds|non_structural_schema_condition_controller_adds|non_structural_schema_condition_controller_depth|non_structural_schema_condition_controller_longest_running_processor_microseconds|non_structural_schema_condition_controller_queue_latency|non_structural_schema_condition_controller_retries|non_structural_schema_condition_controller_unfinished_work_seconds|non_structural_schema_condition_controller_work_duration|rest_client_request_latency_seconds|storage_operation_errors_total|storage_operation_status_count)
+          sourceLabels:
+            - __name__
+      port: https-metrics
+      relabelings:
+        - action: replace
+          sourceLabels:
+            - __metrics_path__
+          targetLabel: metrics_path
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
+      honorTimestamps: false
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: (container_spec_.*|container_file_descriptors|container_sockets|container_threads_max|container_threads|container_start_time_seconds|container_last_seen);;
+          sourceLabels:
+            - __name__
+            - pod
+            - namespace
+        - action: drop
+          regex: (container_blkio_device_usage_total);.+
+          sourceLabels:
+            - __name__
+            - container
+      path: /metrics/cadvisor
+      port: https-metrics
+      relabelings:
+        - action: replace
+          sourceLabels:
+            - __metrics_path__
+          targetLabel: metrics_path
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
+      interval: 30s
+      path: /metrics/probes
+      port: https-metrics
+      relabelings:
+        - action: replace
+          sourceLabels:
+            - __metrics_path__
+          targetLabel: metrics_path
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
+      interval: 5s
+      metricRelabelings:
+        - action: drop
+          regex: process_start_time_seconds
+          sourceLabels:
+            - __name__
+      path: /metrics/slis
+      port: https-metrics
+      relabelings:
+        - action: replace
+          sourceLabels:
+            - __metrics_path__
+          targetLabel: metrics_path
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true

--- a/flux/node-exporter/kustomization.yaml
+++ b/flux/node-exporter/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: node-exporter
+  namespace: flux-system
+namespace: kube-system
+
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/kustomization: node-exporter
+      flux.kub3.uk/name: prometheus
+      flux.kub3.uk/application: node-exporter
+      flux.kub3.uk/component: metrics
+      flux.kub3.uk/managed-by: kustomization
+
+resources:
+  - node-exporter-helm.yaml
+
+configMapGenerator:
+  - name: helm-node-exporter-values
+    files:
+      - values.yaml=node-exporter-values.yaml
+
+configurations:
+  - kustomize-config.yaml

--- a/flux/node-exporter/kustomize-config.yaml
+++ b/flux/node-exporter/kustomize-config.yaml
@@ -1,0 +1,9 @@
+---
+# Automatically update the reference to the ConfigMap containing the HelmRelease
+# values, forcing the resource to reconcile on changes to the configuration
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/flux/node-exporter/node-exporter-helm.yaml
+++ b/flux/node-exporter/node-exporter-helm.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: node-exporter
+spec:
+  chart:
+    spec:
+      sourceRef:
+        kind: HelmRepository
+        namespace: flux-system
+        name: prometheus-community
+      chart: prometheus-node-exporter
+      interval: 5m
+      version: 4.42.0
+  interval: 3h
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  test:
+    enable: true
+  driftDetection:
+    mode: enabled
+
+  valuesFrom:
+    - kind: ConfigMap
+      name: helm-node-exporter-values

--- a/flux/node-exporter/node-exporter-values.yaml
+++ b/flux/node-exporter/node-exporter-values.yaml
@@ -1,0 +1,16 @@
+---
+fullnameOverride: node-exporter
+
+prometheus:
+  monitor:
+    enabled: true
+
+networkPolicy:
+  enabled: false
+
+resources:
+  limits: # Don't limit the CPU
+    memory: 64Mi
+  requests:
+    cpu: 10m
+    memory: 32Mi


### PR DESCRIPTION
Implement the `kube-state-metrics` and the `node-exporter` services for Prometheus to collect Kubernetes and individual node metrics for the cluster's monitoring.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
