### PR TITLE
Implement the `podinfo` service for testing

### DIFF
--- a/flux/cluster/kustomization.yaml
+++ b/flux/cluster/kustomization.yaml
@@ -23,3 +23,4 @@ resources:
   - alertmanager.yaml
   - node-exporter.yaml
   - kube-state-metrics.yaml
+  - podinfo.yaml

--- a/flux/cluster/podinfo.yaml
+++ b/flux/cluster/podinfo.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: podinfo
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: baseline
+  path: podinfo
+  dependsOn:
+    - name: sources
+    - name: prometheus-crds
+  interval: 1h
+  retryInterval: 10m
+  prune: true
+
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: common-substitutions

--- a/flux/podinfo/kustomization.yaml
+++ b/flux/podinfo/kustomization.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: podinfo
+  namespace: flux-system
+namespace: app-podinfo
+
+labels:
+  - includeSelectors: true
+    pairs:
+      flux.kub3.uk/organisation: n3tuk
+      flux.kub3.uk/repository: infra-flux
+      flux.kub3.uk/kustomization: podinfo
+      flux.kub3.uk/name: podinfo
+      flux.kub3.uk/application: podinfo
+      flux.kub3.uk/component: podinfo
+      flux.kub3.uk/managed-by: kustomization
+
+resources:
+  - namespace.yaml
+  - podinfo-helm.yaml
+
+configMapGenerator:
+  - name: helm-podinfo-values
+    files:
+      - values.yaml=podinfo-values.yaml
+
+configurations:
+  - kustomize-config.yaml

--- a/flux/podinfo/kustomize-config.yaml
+++ b/flux/podinfo/kustomize-config.yaml
@@ -1,0 +1,9 @@
+---
+# Automatically update the reference to the ConfigMap containing the HelmRelease
+# values, forcing the resource to reconcile on changes to the configuration
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/flux/podinfo/namespace.yaml
+++ b/flux/podinfo/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-podinfo

--- a/flux/podinfo/podinfo-helm.yaml
+++ b/flux/podinfo/podinfo-helm.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: podinfo
+spec:
+  chart:
+    spec:
+      sourceRef:
+        kind: HelmRepository
+        namespace: flux-system
+        name: podinfo
+      chart: podinfo
+      interval: 5m
+      version: 6.7.1
+  interval: 3h
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  test:
+    enable: false
+  driftDetection:
+    mode: enabled
+
+  valuesFrom:
+    - kind: ConfigMap
+      name: helm-podinfo-values

--- a/flux/podinfo/podinfo-values.yaml
+++ b/flux/podinfo/podinfo-values.yaml
@@ -1,0 +1,49 @@
+---
+replicaCount: 3
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+topologySpreadConstraints:
+  # With three Proxmox nodes and two workers per node, this will ensure that
+  # cert-manager is distributed across multiple nodes, not just multiple workers
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: podinfo
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: podinfo
+
+ingress:
+  enabled: true
+  className: external
+  annotations:
+    external-dns.alpha.kubernetes.io/target: ${cloudflare_tunnel}
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: 'true'
+  hosts:
+    - host: podinfo.${t3st_domain}
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  # TLS is not required as this is a proxied connection from Cloudflare
+  tls: []
+
+resources:
+  limits: # Don't limit the CPU
+    memory: 256Mi
+  requests:
+    cpu: 10m
+    memory: 64Mi

--- a/flux/sources/kustomization.yaml
+++ b/flux/sources/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - ingress-nginx.yaml
   - metallb.yaml
   - prometheus-community.yaml
+  - podinfo.yaml

--- a/flux/sources/podinfo.yaml
+++ b/flux/sources/podinfo.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: podinfo
+spec:
+  url: https://stefanprodan.github.io/podinfo
+  interval: 24h


### PR DESCRIPTION
Implement the example service `podinfo` as an end-to-end test service on the cluster. This will form the basis of testing and developing connectivity from the public internet as well as internal services such as `cert-manager`, Prometheus, and Flux.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
