### PR TITLE
Add Flux Providers and Notifications

### DIFF
--- a/flux/cluster/custom-resources.yaml
+++ b/flux/cluster/custom-resources.yaml
@@ -12,6 +12,7 @@ spec:
   interval: 1h
   retryInterval: 10m
   prune: true
+  force: true
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -26,6 +27,7 @@ spec:
   interval: 1h
   retryInterval: 10m
   prune: true
+  force: true
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -40,3 +42,4 @@ spec:
   interval: 1h
   retryInterval: 10m
   prune: true
+  force: true

--- a/flux/cluster/flux.yaml
+++ b/flux/cluster/flux.yaml
@@ -20,3 +20,5 @@ spec:
     substituteFrom:
       - kind: ConfigMap
         name: common-substitutions
+      - kind: Secret
+        name: flux-substitutions

--- a/flux/flux/kustomization.yaml
+++ b/flux/flux/kustomization.yaml
@@ -20,10 +20,15 @@ labels:
 resources:
   # Namespace already created during bootstrapping
   - flux-helm.yaml
+  - secrets.yaml
+  - provider-slack.yaml
+  - provider-pagerduty.yaml
+  - notifications.yaml
 
 configMapGenerator:
   - name: helm-flux-values
-    options:
-      disableNameSuffixHash: true
     files:
       - values.yaml=flux-values.yaml
+
+configurations:
+  - kustomize-config.yaml

--- a/flux/flux/kustomization.yaml
+++ b/flux/flux/kustomization.yaml
@@ -7,7 +7,7 @@ metadata:
 namespace: flux-system
 
 labels:
-  - includeSelectors: true
+  - includeSelectors: false
     pairs:
       flux.kub3.uk/organisation: n3tuk
       flux.kub3.uk/repository: infra-flux

--- a/flux/flux/kustomize-config.yaml
+++ b/flux/flux/kustomize-config.yaml
@@ -1,0 +1,9 @@
+---
+# Automatically update the reference to the ConfigMap containing the HelmRelease
+# values, forcing the resource to reconcile on changes to the configuration
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/flux/flux/notifications.yaml
+++ b/flux/flux/notifications.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: flux-baseline-slack
+spec:
+  eventSources:
+    - kind: OCIRepository
+      namespace: flux-system
+      name: baseline
+  eventSeverity: info
+  eventMetadata:
+    Namespace: flux-system
+    OCIRepository: baseline
+    Cluster: ${cluster}
+  providerRef:
+    name: slack
+  summary: >-
+    Update to the baseline OCIRepository resource containing all Flux-managed
+    resources and Kustomizations.
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: flux-baseline-pagerduty
+spec:
+  eventSources:
+    - kind: OCIRepository
+      namespace: flux-system
+      name: baseline
+  eventSeverity: error
+  eventMetadata:
+    Namespace: flux-system
+    OCIRepository: baseline
+    Cluster: ${cluster}
+  providerRef:
+    name: pagerduty
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: flux-kustomizations-slack
+spec:
+  eventSources:
+    - kind: Kustomization
+      name: '*'
+  eventSeverity: info
+  eventMetadata:
+    Cluster: ${cluster}
+  providerRef:
+    name: slack
+  exclusionList:
+    - ^Dependencies do not meet ready condition
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: flux-kustomizations-pagerduty
+spec:
+  eventSources:
+    - kind: Kustomization
+      name: '*'
+  eventSeverity: error
+  eventMetadata:
+    Cluster: ${cluster}
+  providerRef:
+    name: pagerduty
+  exclusionList:
+    - ^Dependencies do not meet ready condition
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: helm-flux-slack
+spec:
+  eventSources:
+    - kind: HelmRelease
+      namespace: flux-system
+      name: flux
+  eventSeverity: info
+  eventMetadata:
+    Namespace: flux-system
+    HelmRelease: flux
+    Cluster: ${cluster}
+  providerRef:
+    name: slack
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: helm-flux-pagerduty
+spec:
+  eventSources:
+    - kind: HelmRelease
+      namespace: flux-system
+      name: flux
+  eventSeverity: error
+  eventMetadata:
+    Namespace: flux-system
+    HelmRelease: flux
+    Cluster: ${cluster}
+  providerRef:
+    name: pagerduty

--- a/flux/flux/provider-pagerduty.yaml
+++ b/flux/flux/provider-pagerduty.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: pagerduty
+spec:
+  type: pagerduty
+  address: https://events.eu.pagerduty.com
+  channel: ${flux_pagerduty_key}

--- a/flux/flux/provider-slack.yaml
+++ b/flux/flux/provider-slack.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: slack
+spec:
+  type: slack
+  address: https://slack.com/api/chat.postMessage
+  secretRef:
+    name: notification-slack-token
+  channel: kub3-${cluster}-flux

--- a/flux/flux/secrets.yaml
+++ b/flux/flux/secrets.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: notification-slack-token
+stringData:
+  token: ${flux_slack_token}

--- a/flux/podinfo/kustomization.yaml
+++ b/flux/podinfo/kustomization.yaml
@@ -4,10 +4,9 @@ kind: Kustomization
 metadata:
   name: podinfo
   namespace: flux-system
-namespace: app-podinfo
 
 labels:
-  - includeSelectors: true
+  - includeSelectors: false
     pairs:
       flux.kub3.uk/organisation: n3tuk
       flux.kub3.uk/repository: infra-flux
@@ -22,7 +21,8 @@ resources:
   - podinfo-helm.yaml
 
 configMapGenerator:
-  - name: helm-podinfo-values
+  - namespace: app-podinfo
+    name: helm-podinfo-values
     files:
       - values.yaml=podinfo-values.yaml
 

--- a/flux/podinfo/kustomization.yaml
+++ b/flux/podinfo/kustomization.yaml
@@ -19,6 +19,7 @@ labels:
 resources:
   - namespace.yaml
   - podinfo-helm.yaml
+  - notifications.yaml
 
 configMapGenerator:
   - namespace: app-podinfo

--- a/flux/podinfo/kustomize-config.yaml
+++ b/flux/podinfo/kustomize-config.yaml
@@ -5,5 +5,5 @@ nameReference:
   - kind: ConfigMap
     version: v1
     fieldSpecs:
-      - path: spec/valuesFrom/name
-        kind: HelmRelease
+      - kind: HelmRelease
+        path: spec/valuesFrom/name

--- a/flux/podinfo/notifications.yaml
+++ b/flux/podinfo/notifications.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: helm-podinfo-slack
+  namespace: flux-system
+spec:
+  eventSources:
+    - kind: HelmRelease
+      namespace: app-podinfo
+      name: podinfo
+  eventSeverity: info
+  eventMetadata:
+    Repository: https://github.com/n3tuk/infra-flux
+    Kustomization: podinfo
+    Namespace: app-podinfo
+    Name: podinfo
+    Cluster: ${cluster}
+  providerRef:
+    name: slack
+  summary: podinfo HelmRelease
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: helm-podinfo-pagerduty
+  namespace: flux-system
+spec:
+  eventSources:
+    - kind: HelmRelease
+      namespace: app-podinfo
+      name: podinfo
+  eventSeverity: info
+  eventMetadata:
+    Repository: https://github.com/n3tuk/infra-flux
+    Kustomization: podinfo
+    Namespace: app-podinfo
+    Name: podinfo
+    Cluster: ${cluster}
+  providerRef:
+    name: pagerduty

--- a/flux/podinfo/podinfo-helm.yaml
+++ b/flux/podinfo/podinfo-helm.yaml
@@ -3,6 +3,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: podinfo
+  namespace: app-podinfo
 spec:
   chart:
     spec:

--- a/flux/prometheus/ingress.yaml
+++ b/flux/prometheus/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: prometheus
-  namespace: prometheus-system
+  namespace: prometheus-metrics
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-cloudflare-production
   labels:

--- a/flux/prometheus/kustomization.yaml
+++ b/flux/prometheus/kustomization.yaml
@@ -4,10 +4,9 @@ kind: Kustomization
 metadata:
   name: prometheus-metrics
   namespace: flux-system
-namespace: prometheus-metrics
 
 labels:
-  - includeSelectors: true
+  - includeSelectors: false
     pairs:
       flux.kub3.uk/organisation: n3tuk
       flux.kub3.uk/repository: infra-flux

--- a/flux/prometheus/prometheus.yaml
+++ b/flux/prometheus/prometheus.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
   name: metrics
+  namespace: prometheus-metrics
   labels:
     prometheus: metrics
 spec:
@@ -74,9 +75,7 @@ spec:
       alertmanager: metrics
 
   externalLabels:
-    environment: ${environment}
-    cluster: ${cluster_domain}
-    location: bridgend
+    cluster: ${cluster}
 
   alerting:
     alertmanagers:

--- a/flux/prometheus/service-account.yaml
+++ b/flux/prometheus/service-account.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus
+  namespace: prometheus-metrics
   labels:
     prometheus: metrics
 ---

--- a/flux/prometheus/service-monitor.yaml
+++ b/flux/prometheus/service-monitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: prometheus
+  namespace: prometheus-metrics
   labels:
     prometheus: metrics
 spec:

--- a/flux/prometheus/service.yaml
+++ b/flux/prometheus/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus
+  namespace: prometheus-metrics
   labels:
     prometheus: metrics
 spec:

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -20,6 +20,7 @@ TODO
 | Name | Version |
 |------|---------|
 | <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | 4.43.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.6.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.25.2 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
 
@@ -44,10 +45,14 @@ No modules.
 | [kubernetes_secret_v1.flux_system_cert_manager_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [kubernetes_secret_v1.flux_system_cloudflared_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [kubernetes_secret_v1.flux_system_external_dns_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [kubernetes_secret_v1.flux_system_flux_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [kubernetes_secret_v1.proxmox_csi_substitutions](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [random_password.tunnel](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [cloudflare_api_token_permission_groups.all](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/data-sources/api_token_permission_groups) | data source |
 | [cloudflare_zone.n3tuk](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/data-sources/zone) | data source |
+| [google_secret_manager_secret_version.flux_pagerduty_key](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret_version) | data source |
+| [google_secret_manager_secret_version.flux_slack_token](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret_version) | data source |
+| [google_secret_manager_secret_version.proxmox_csi_plugin_token_secret](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret_version) | data source |
 
 ## Inputs
 
@@ -58,7 +63,6 @@ No modules.
 | <a name="input_metallb_pool_ipv6"></a> [metallb\_pool\_ipv6](#input\_metallb\_pool\_ipv6) | A CIDR for the IPv6 addresses to be used for metallb-managed LoadBalancer endpoints | `string` | n/a | yes |
 | <a name="input_metallb_routers"></a> [metallb\_routers](#input\_metallb\_routers) | A list of router IP addresses for each Proxmox Node for metallb | <pre>object({<br/>    proxmox-01 = string<br/>    proxmox-02 = string<br/>    proxmox-03 = string<br/>  })</pre> | n/a | yes |
 | <a name="input_proxmox_csi_plugin_token_id"></a> [proxmox\_csi\_plugin\_token\_id](#input\_proxmox\_csi\_plugin\_token\_id) | The API token name to provide the proxmox-csi-plugin resource access to the Proxmox API for Ceph | `string` | n/a | yes |
-| <a name="input_proxmox_csi_plugin_token_secret"></a> [proxmox\_csi\_plugin\_token\_secret](#input\_proxmox\_csi\_plugin\_token\_secret) | The API token secret to provide the proxmox-csi-plugin resource access to the Proxmox API for Ceph | `string` | n/a | yes |
 | <a name="input_root_domain"></a> [root\_domain](#input\_root\_domain) | The root external domain name of the EKS Cluster (i.e. the domain suffix for selected services) | `string` | n/a | yes |
 | <a name="input_sit3_domain"></a> [sit3\_domain](#input\_sit3\_domain) | The external domain name of the EKS Cluster using the sit3.uk domain | `string` | n/a | yes |
 | <a name="input_t3st_domain"></a> [t3st\_domain](#input\_t3st\_domain) | The external domain name of the EKS Cluster using the t3st.uk domain | `string` | n/a | yes |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -64,3 +64,26 @@ resource "kubernetes_manifest" "flux_system_cluster" {
     kubernetes_manifest.flux_system_baseline
   ]
 }
+
+resource "kubernetes_secret_v1" "flux_system_flux_substitutions" {
+  metadata {
+    name      = "flux-substitutions"
+    namespace = "flux-system"
+
+    labels = merge(local.kubernetes_labels, {
+      "flux.kub3.uk/name"     = "flux"
+      "flux.kub3.uk/instance" = "flux"
+    })
+  }
+
+  type = "Opaque"
+
+  data = {
+    flux_slack_token   = data.google_secret_manager_secret_version.flux_slack_token.secret_data
+    flux_pagerduty_key = data.google_secret_manager_secret_version.flux_pagerduty_key.secret_data
+  }
+
+  depends_on = [
+    kubernetes_manifest.flux_system_baseline
+  ]
+}

--- a/terraform/proxmox-csi.tf
+++ b/terraform/proxmox-csi.tf
@@ -30,6 +30,6 @@ resource "kubernetes_secret_v1" "proxmox_csi_substitutions" {
   type = "Opaque"
 
   data = {
-    proxmox_csi_token_secret = var.proxmox_csi_plugin_token_secret
+    proxmox_csi_token_secret = data.google_secret_manager_secret_version.proxmox_csi_plugin_token_secret.secret_data
   }
 }

--- a/terraform/secret.tf
+++ b/terraform/secret.tf
@@ -1,0 +1,12 @@
+data "google_secret_manager_secret_version" "proxmox_csi_plugin_token_secret" {
+  secret = "github-infra-flux-${terraform.workspace}-proxmox-csi-plugin-token-secret"
+}
+
+data "google_secret_manager_secret_version" "flux_slack_token" {
+  secret = "github-infra-flux-${terraform.workspace}-flux-slack-token"
+
+}
+
+data "google_secret_manager_secret_version" "flux_pagerduty_key" {
+  secret = "github-infra-flux-${terraform.workspace}-flux-pagerduty-key"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -60,12 +60,6 @@ variable "proxmox_csi_plugin_token_id" {
   # required
 }
 
-variable "proxmox_csi_plugin_token_secret" {
-  description = "The API token secret to provide the proxmox-csi-plugin resource access to the Proxmox API for Ceph"
-  type        = string
-  # required
-}
-
 variable "cloudflare_account_id" {
   description = "The Account ID for the Cloudflare account to be used"
   type        = string

--- a/terraform/variables/production.tfvars
+++ b/terraform/variables/production.tfvars
@@ -3,8 +3,7 @@ root_domain    = "kub3.uk"
 t3st_domain    = "t3st.uk"
 sit3_domain    = "sit3.uk"
 
-proxmox_csi_plugin_token_id     = "kubernetes-csi@pve!csi"
-proxmox_csi_plugin_token_secret = ""
+proxmox_csi_plugin_token_id = "kubernetes-csi@pve!csi"
 
 metallb_pool_ipv4 = "172.23.0.64/26"
 metallb_pool_ipv6 = "2a02:8010:8006:3a00::/64"


### PR DESCRIPTION
Implement the initial providers (Slack and Pagerduty) and the first common `Notification` resources to monitor the deployment of `Kustomization` manifests by Flux on each cluster.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
