### PR TITLE
Fix time settings for Dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,7 +6,7 @@ updates:
     directory: /
     schedule:
       interval: daily
-      time: 18:00
+      time: '18:00'
       timezone: Europe/London
     commit-message:
       prefix: actions
@@ -20,7 +20,7 @@ updates:
     directory: terraform/
     schedule:
       interval: daily
-      time: 18:30
+      time: '18:30'
       timezone: Europe/London
     commit-message:
       prefix: terraform


### PR DESCRIPTION
Fix the time settings for the Dependabot configuration as these must be strings not numbers or time references.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
