### PR TITLE
INC-24: Remove the data sources for Grafana

### DIFF
--- a/flux/grafana/grafana-values.yaml
+++ b/flux/grafana/grafana-values.yaml
@@ -35,27 +35,6 @@ persistence:
   enabled: true
   storageClassName: proxmox-rbd-ext4
 
-datasources:
-  datasources.yaml:
-    apiVersion: 1
-    datasources:
-      - name: Prometheus
-        type: prometheus
-        uuid: 707eab40-3d36-46ad-bd75-9484fc3be3ff
-        url: http://prometheus.prometheus-metrics.svc:9090
-        access: proxy
-        isDefault: true
-        editable: true
-      - name: Elasticsearch
-        type: elasticsearch
-        uuid: 1d2896a9-b3f3-453b-af98-e1f457c0c7b5
-        url: http://logs-es-http.elastic-logs.svc:9200
-        access: proxy
-        isDefault: false
-        editable: true
-        jsonData:
-          timeField: '@timestamp'
-
 imageRenderer:
   deploymentStrategy:
     type: RollingUpdate


### PR DESCRIPTION
Remove the pre-configured `datasources` for Grafana as these seem to be causing issues with those stored within the `StatefulSet`, and hence causing Grafana to CrashLoop on initialisation.

This should resolve [INC-24](https://app.incident.io/n3tuk/incidents/24).

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
