### PR TITLE
INC-14: Correct the label merge for `ContainerWaiting` alert

### DIFF
--- a/flux/prometheus-rules/workloads.yaml
+++ b/flux/prometheus-rules/workloads.yaml
@@ -84,9 +84,8 @@ spec:
           expr: |-
             sum by (namespace, pod, container, reason) (
               kube_pod_container_status_waiting_reason
-            ) * on(namespace, pod)
-                group_left(node)
-                kube_node_info
+            ) * on(namespace, pod) group_left(node)
+                kube_pod_info
             > 0
           for: 15m
           annotations:


### PR DESCRIPTION
Correct the series used for merging the node label for the `ContainerWaiting` alert in Prometheus. The information is in the `kube_pod_info`, which is used in all other Alerts, whereas `kube_node_info` seems to have occasional duplicate values breaking the check.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
