### PR TITLE
INC-23: Refactor the TSDB Series `Alert` in Prometheus

### DIFF
--- a/flux/prometheus-rules/prometheus.yaml
+++ b/flux/prometheus-rules/prometheus.yaml
@@ -664,37 +664,43 @@ spec:
             incidentio: create
             team: platform
 
-        - alert: PrometheusTSDBSeriesIncreaseWarning
+        - alert: PrometheusTSDBSeriesIncreaseNotice
           expr: |-
-            (
-              increase(
-                prometheus_tsdb_head_series_created_total[1d]
-              ) /
+            sum(
+              sum_over_time(
+                scrape_series_added[3h]
+              )
+            ) > (
+              0.01 *
               (
-                prometheus_tsdb_head_series -
-                increase(
-                  prometheus_tsdb_head_series_created_total[1d]
+                max(
+                  prometheus_tsdb_head_series
+                )
+              -
+                sum(
+                  sum_over_time(
+                    scrape_series_added[1h]
+                  )
                 )
               )
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
-            > 0.25
-          for: 1m
+            )
+          for: 3h
+          keep_firing_for: 15m
           annotations:
-            title: Prometheus TSDB Series Increase
+            title: Prometheus TSDB Sustained Increase in Series
             summary: >-
-              One or more of the Prometheus `Pods` in the `{{$externalLabels.cluster}}` Cluster have
-              seen *a large increase in the number of series recorded* within the TSDB, expanding by
-              greater than 10%* within the last 24 hours.
+              The Prometheus service in the `{{$externalLabels.cluster}}` Cluster has seen *a large
+              increase in the number of series added* within the TSDB, *expanding by more than 1%
+              per hour* during at least each of the last three hours. Long-term rapid growth in
+              metrics may slow down processing metrics and increase usage of the underlying PVCs.
             description: >-
-              `{{$labels.pod}}` on `Node` `{{$labels.node}}`
-              (*{{$value|humanizePercentage}}* increase)
+              *{{$value|humanize}}* metrics added
           labels:
             ignore: outside-extended-hours
-            severity: warning
+            severity: info
             slack: kub3-${cluster}-alerts-infra
-            pagerduty: send
-            incidentio: create
+            pagerduty: ignore
+            incidentio: ignore
             team: platform
 
         - alert: PrometheusTSDBSeriesCardinalityWarning


### PR DESCRIPTION
Refactor the monitoring of the increase in the series managed by the TSDB in Prometheus such that it works off the noted new series from the scrapes and not the database and alerts on a more sustained rate of increase.

Specifically, it will monitor the increases over the last hour, and only then will it alert if the series increases exceed 1% per hour for more than three hours. This is as opposed to a single sudden large increase, which may be more expected.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
