### PR TITLE
INC-31: Refactor the `kube_pod_info` label merging for all `PrometheusRules`

### DIFF
--- a/flux/alertmanager/slack.yaml
+++ b/flux/alertmanager/slack.yaml
@@ -19,11 +19,13 @@ spec:
       - receiver: infrastructure
         matchers:
           - name: slack
+            matchType: =
             value: kub3-${cluster}-alerts-infra
         continue: true
       - receiver: applications
         matchers:
           - name: slack
+            matchType: =
             value: kub3-${cluster}-alerts-applications
         continue: true
     repeatInterval: 3h

--- a/flux/cert-manager/prometheus-rules.yaml
+++ b/flux/cert-manager/prometheus-rules.yaml
@@ -126,8 +126,11 @@ spec:
                 certmanager_controller_sync_error_count{
                   namespace="certificates-system"
                 }[5m]
-              ) * on(pod) group_left(node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 1
           for: 5m
           annotations:
@@ -158,9 +161,11 @@ spec:
                   }[1h]
                 )
               )
-            ) * on(pod) group_left(node)
-            kube_pod_info
-            > 2
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 2
           for: 30m
           annotations:
             title: >-

--- a/flux/core-dns/prometheus-rules.yaml
+++ b/flux/core-dns/prometheus-rules.yaml
@@ -45,14 +45,17 @@ spec:
         - alert: CoreDNSRequestLatencyWarning
           expr: |-
             histogram_quantile(0.99,
-              sum by(pod, server, zone, le) (
+              sum by(namespace, pod, server, zone, le) (
                 rate(
                   coredns_dns_request_duration_seconds_bucket{
                     job="kube-dns"
                   }[5m]
                 )
-              ) * on(pod) group_left(node, namespace)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 0.2
           for: 5m
           annotations:
@@ -76,14 +79,17 @@ spec:
         - alert: CoreDNSRequestLatencyCritical
           expr: |-
             histogram_quantile(0.99,
-              sum by(pod, server, zone, le) (
+              sum by(namespace, pod, server, zone, le) (
                 rate(
                   coredns_dns_request_duration_seconds_bucket{
                     job="kube-dns"
                   }[5m]
                 )
-              ) * on(pod) group_left(node, namespace)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 0.5
           for: 3m
           annotations:
@@ -106,7 +112,7 @@ spec:
 
         - alert: CoreDNSErrorsWarning
           expr: |-
-            sum by (pod, server, zone) (
+            sum by (namespace, pod, server, zone) (
               rate(
                 coredns_dns_responses_total{
                   job="kube-dns",
@@ -114,15 +120,57 @@ spec:
                 }[5m]
               )
             ) /
-            sum by (pod, server, zone) (
+            sum by (namespace, pod, server, zone) (
               rate(
                 coredns_dns_responses_total{
                   job="kube-dns"
                 }[5m]
               )
-            ) * on(pod) group_left(node)
-            kube_pod_info
-            > 0.025
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0.5
+          for: 3m
+          annotations:
+            title: CoreDNS Request Latency
+            summary: >-
+              One of more of the CoreDNS `Pods` in the `{{$externalLabels.cluster}}` Cluster are
+              reporting a *99th percentile latency of 500ms or more* for one or more endpoints and
+              zones for at least the last three minutes, which is above the *critical* threshold.
+            description: >-
+              `{{$labels.pod}}` on `{{$labels.node}}` `Node` (*{{$value|humanizeDuration}}* to
+              `{{$labels.server}}` for `{{$labels.zone}}` Zone)
+            runbook: https://d.n3t.uk/runbooks/
+          labels:
+            ignore: never
+            severity: critical
+            slack: kub3-${cluster}-alerts-infra
+            pagerduty: send
+            incidentio: create
+            team: platform
+
+        - alert: CoreDNSErrorsWarning
+          expr: |-
+            sum by (namespace, pod, server, zone) (
+              rate(
+                coredns_dns_responses_total{
+                  job="kube-dns",
+                  rcode="SERVFAIL"
+                }[5m]
+              )
+            ) /
+            sum by (namespace, pod, server, zone) (
+              rate(
+                coredns_dns_responses_total{
+                  job="kube-dns"
+                }[5m]
+              )
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0.025
           for: 5m
           annotations:
             title: CoreDNS Internal Error Rate
@@ -144,7 +192,7 @@ spec:
 
         - alert: CoreDNSErrorsCritical
           expr: |-
-            sum by (pod, server, zone) (
+            sum by (namespace, pod, server, zone) (
               rate(
                 coredns_dns_responses_total{
                   job="kube-dns",
@@ -158,9 +206,11 @@ spec:
                   job="kube-dns"
                 }[5m]
               )
-            ) * on(pod) group_left(node)
-            kube_pod_info
-            > 0.1
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0.1
           for: 5m
           annotations:
             title: CoreDNS Internal Error Rate
@@ -185,16 +235,18 @@ spec:
         - alert: CoreDNSProxyLatencyWarning
           expr: |-
             histogram_quantile(0.99,
-              sum by(pod, proxy_name, to, le) (
+              sum by(namespace, pod, proxy_name, to, le) (
                 rate(
                   coredns_proxy_request_duration_seconds_bucket{
                     job="kube-dns"
                   }[5m]
                 )
               )
-            ) * on(pod) group_left(node)
-            kube_pod_info
-            > 0.35
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0.35
           for: 10m
           annotations:
             title: CoreDNS Proxy Latency
@@ -217,16 +269,18 @@ spec:
         - alert: CoreDNSProxyLatencyCritical
           expr: |-
             histogram_quantile(0.99,
-              sum by(pod, proxy_name, to, le) (
+              sum by(namespace, pod, proxy_name, to, le) (
                 rate(
                   coredns_proxy_request_duration_seconds_bucket{
                     job="kube-dns"
                   }[5m]
                 )
               )
-            ) * on(pod) group_left(node)
-            kube_pod_info
-            > 0.75
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0.75
           for: 3m
           annotations:
             title: CoreDNS Proxy Latency
@@ -248,16 +302,17 @@ spec:
 
         - alert: CoreDNSProxyHealthcheckFailure
           expr: |-
-            sum by (pod, proxy_name, to) (
+            sum by (namespace, pod, proxy_name, to) (
               rate(
                 coredns_proxy_healthcheck_failures_total{
                   job="kube-dns"
                 }[2m]
               )
-            ) * on(pod)
-                group_left(node)
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
                 kube_pod_info
-            > 1
+              )
+            ) > 1
           for: 3m
           annotations:
             title: CoreDNS Proxy Health Checks Failures
@@ -283,10 +338,11 @@ spec:
               coredns_forward_healthcheck_broken_total{
                 job="kube-dns"
               }[5m]
-            ) * on(pod)
-                group_left(node, created_by_kind, created_by_name)
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
                 kube_pod_info
-            > 0
+              )
+            ) > 0
           for: 2m
           annotations:
             title: CoreDNS Proxy Health Checks Failures

--- a/flux/external-dns/prometheus-rules.yaml
+++ b/flux/external-dns/prometheus-rules.yaml
@@ -15,9 +15,11 @@ spec:
             ( time()
                 -
               external_dns_controller_last_reconcile_timestamp_seconds
-            ) * on(namespace, pod) group_left(node)
-            kube_pod_info
-            > 3600
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 3600
           for: 10m
           annotations:
             title: >-
@@ -47,9 +49,11 @@ spec:
           expr: |-
             increase(
               external_dns_source_errors_total[1h]
-            ) * on(namespace, pod) group_left(node)
-            kube_pod_info
-            > 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0
           for: 1m
           annotations:
             title: >-
@@ -74,9 +78,11 @@ spec:
           expr: |-
             increase(
               external_dns_registry_errors_total[1h]
-            ) * on(namespace, pod) group_left(node)
-            kube_pod_info
-            > 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0
           for: 1m
           annotations:
             title: >-

--- a/flux/fluent-bit/prometheus-rules.yaml
+++ b/flux/fluent-bit/prometheus-rules.yaml
@@ -14,9 +14,11 @@ spec:
           expr: |-
             rate(
               fluentbit_output_retries_failed_total[1m]
-            ) * on(pod) group_left(node)
-            kube_pod_info
-            > 0.1
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0.1
           for: 5m
           annotations:
             title: Excessive Retries Detected for Logs in Fluent Bit
@@ -44,9 +46,11 @@ spec:
           expr: |-
             rate(
               fluentbit_output_dropped_records_total[1m]
-            ) * on(pod) group_left(node)
-            kube_pod_info
-            > 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0
           for: 5m
           annotations:
             title: Excessive Drops Detected for Logs in Fluent Bit
@@ -98,9 +102,11 @@ spec:
               fluentbit_input_records_total{
                 name="kubernetes-logs"
               }[1m]
-            ) * on(pod) group_left(node)
-            kube_pod_info
-            == 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) == 0
           for: 5m
           annotations:
             title: No Kubernetes Container Logs Processed by Fluent Bit
@@ -133,9 +139,11 @@ spec:
                   name="kubernetes-logs"
                 }[1m]
               ) > 0
-            ) * on(pod) group_left(node)
-            kube_pod_info
-            == 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) == 0
           for: 5m
           annotations:
             title: No Kubernetes Metadata Processed for Logs by Fluent Bit
@@ -161,8 +169,11 @@ spec:
                 fluentbit_input_records_total{
                   name="kubernetes-audit"
                 }[1m]
-              ) * on(pod) group_left(node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) == 0
           for: 5m
           annotations:
@@ -215,9 +226,11 @@ spec:
               fluentbit_input_records_total{
                 name="kubernetes-events"
               }[1m]
-            ) * on(pod) group_left(node)
-            kube_pod_info
-            == 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) == 0
           for: 15m
           annotations:
             title: No Kubernetes Events Processed by Fluent Bit

--- a/flux/kube-state-metrics/prometheus-rules.yaml
+++ b/flux/kube-state-metrics/prometheus-rules.yaml
@@ -25,9 +25,11 @@ spec:
                   kube_state_metrics_list_total[5m]
                 )
               )
-            ) * on(namespace, pod) group_left(node)
-            kube_pod_info
-            > 0.01
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0.01
           for: 15m
           annotations:
             title: >-
@@ -67,10 +69,11 @@ spec:
                   kube_state_metrics_watch_total[5m]
                 )
               )
-            ) * on(namespace, pod)
-                group_left(node)
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
                 kube_pod_info
-            > 0.01
+              )
+            ) > 0.01
           for: 15m
           annotations:
             title: >-
@@ -95,9 +98,11 @@ spec:
           expr: |
             stdvar by (namespace, pod) (
               kube_state_metrics_total_shards
-            ) * on(namespace, pod) group_left(node)
-            kube_pod_info
-            != 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) != 0
           annotations:
             title: >-
               `kube-state-metrics` Sharding is Misconfigured
@@ -132,10 +137,11 @@ spec:
                       kube_state_metrics_shard_ordinal
                     )
               )
-            ) * on(namespace, pod)
-                group_left(node)
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
                 kube_pod_info
-            != 0
+              )
+            ) != 0
           for: 15m
           annotations:
             title: >-

--- a/flux/metallb/prometheus-rules.yaml
+++ b/flux/metallb/prometheus-rules.yaml
@@ -75,8 +75,11 @@ spec:
               metallb_k8s_client_config_stale_bool{
                 job=~"metallb"
               } == 1
-            ) * on (namespace, pod) group_left(node)
-            kube_pod_info
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            )
           for: 1m
           annotations:
             title: >-
@@ -103,8 +106,11 @@ spec:
               metallb_k8s_client_config_loaded_bool{
                 job=~"metallb"
               } == 0
-            ) * on (namespace, pod) group_left(node)
-            kube_pod_info
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            )
           for: 1m
           annotations:
             title: >-
@@ -210,8 +216,11 @@ spec:
               metallb_speaker_announced{
                 job=~"metallb"
               } == 0
-            ) * on (namespace, pod) group_left(node)
-            kube_pod_info
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            )
           for: 2m
           annotations:
             title: >-
@@ -237,8 +246,11 @@ spec:
               metalb_bgp_session_up{
                 job=~"metallb"
               } == 0
-            ) * on (namespace, pod) group_left(node)
-            kube_pod_info
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            )
           for: 2m
           annotations:
             title: >-
@@ -263,8 +275,11 @@ spec:
               metallb_bfd_session_up{
                 job=~"metallb"
               } == 0
-            ) * on (namespace, pod) group_left(node)
-            kube_pod_info
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            )
           for: 3m
           annotations:
             title: >-

--- a/flux/prometheus-rules/alertmanager.yaml
+++ b/flux/prometheus-rules/alertmanager.yaml
@@ -18,9 +18,11 @@ spec:
               alertmanager_config_last_reload_successful{
                 job="alertmanager"
               }[5m]
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
-            == 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) == 0
           for: 10m
           annotations:
             title: Alertmanager Configuration Reload Failed
@@ -80,8 +82,11 @@ spec:
                 alertmanager_cluster_members{
                   job="alertmanager"
                 }[5m]
-              ) * on (namespace, pod) group_left (node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) < on (job) group_left
             count by (job) (
               max_over_time(
@@ -118,8 +123,11 @@ spec:
                     job="alertmanager",
                     integration!~"pagerduty|slack|webhook"
                   }[5m]
-                ) * on (namespace, pod) group_left (node)
-                kube_pod_info
+                ) * on (namespace, pod) group_left (node) (
+                  group by (node, namespace, pod) (
+                    kube_pod_info
+                  )
+                )
               ) / ignoring (pod, reason) group_left
               rate(
                 alertmanager_notifications_total{
@@ -157,8 +165,11 @@ spec:
                     job="alertmanager",
                     integration="slack"
                   }[5m]
-                ) * on (namespace, pod) group_left (node)
-                kube_pod_info
+                ) * on (namespace, pod) group_left (node) (
+                  group by (node, namespace, pod) (
+                    kube_pod_info
+                  )
+                )
               ) / ignoring (reason)
                   group_left
                   rate(
@@ -196,8 +207,11 @@ spec:
                     job="alertmanager",
                     integration=~"pagerduty"
                   }[5m]
-                ) * on (namespace, pod) group_left (node)
-                kube_pod_info
+                ) * on (namespace, pod) group_left (node) (
+                  group by (node, namespace, pod) (
+                    kube_pod_info
+                  )
+                )
               ) / ignoring (reason)
                   group_left
                   rate(
@@ -235,8 +249,11 @@ spec:
                     job="alertmanager",
                     integration=~"webhook"
                   }[5m]
-                ) * on (namespace, pod) group_left (node)
-                kube_pod_info
+                ) * on (namespace, pod) group_left (node) (
+                  group by (node, namespace, pod) (
+                    kube_pod_info
+                  )
+                )
               ) / ignoring (reason)
                   group_left
                   rate(
@@ -340,9 +357,11 @@ spec:
                   job="alertmanager"
                 }
               )
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
-            >= 0.5
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) >= 0.5
           for: 5m
           annotations:
             title: Alertmanager Instances Crashing

--- a/flux/prometheus-rules/kubernetes.yaml
+++ b/flux/prometheus-rules/kubernetes.yaml
@@ -60,8 +60,11 @@ spec:
                 rate(
                   rest_client_requests_total[5m]
                 )
-              ) * on(namespace, pod) group_left(node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 0.01
           for: 15m
           annotations:

--- a/flux/prometheus-rules/nodes.yaml
+++ b/flux/prometheus-rules/nodes.yaml
@@ -115,8 +115,11 @@ spec:
               node_timex_offset_seconds{
                 namespace="kube-system",
                 job="prometheus-node-exporter"
-              } * on (namespace, pod) group_left (node)
-              kube_pod_info
+              } * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 0.05
           for: 10m
           annotations:
@@ -143,8 +146,11 @@ spec:
               node_timex_offset_seconds{
                 namespace="kube-system",
                 job="prometheus-node-exporter"
-              } * on (namespace, pod) group_left (node)
-              kube_pod_info
+              } * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) >= 0.25
           for: 1m
           annotations:

--- a/flux/prometheus-rules/prometheus.yaml
+++ b/flux/prometheus-rules/prometheus.yaml
@@ -16,8 +16,11 @@ spec:
               prometheus_rule_group_last_duration_seconds
                 >
               ( prometheus_rule_group_interval_seconds / 2 )
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            )
           for: 5m
           annotations:
             title: Slow Prometheus Rule Group Evaluation
@@ -47,8 +50,11 @@ spec:
               prometheus_rule_group_last_duration_seconds
                 >
               prometheus_rule_group_interval_seconds
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            )
           for: 5m
           annotations:
             title: Slow Prometheus Rule Group Evaluation
@@ -71,9 +77,11 @@ spec:
           expr: |-
             min_over_time(
               prometheus_notifications_queue_length[15m]
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
-            > 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0
           for: 1m
           annotations:
             title: Prometheus Alert Notification Queue Backlog
@@ -107,8 +115,11 @@ spec:
                   job="prometheus"
                 }[5m]
               )
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            )
           for: 15m
           annotations:
             title: Prometheus Alert Notification Queue Warning
@@ -137,8 +148,11 @@ spec:
                   job="prometheus"
                 }[5m]
               ) == 0
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            )
           for: 10m
           annotations:
             title: Prometheus Config Reload Failure
@@ -162,8 +176,11 @@ spec:
                 prometheus_sd_refresh_failures_total{
                   job="prometheus"
                 }[10m]
-              ) * on (namespace, pod) group_left (node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 0
           for: 20m
           annotations:
@@ -190,9 +207,11 @@ spec:
                   prometheus_rule_evaluation_failures_total[5m]
                 )
               )
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
-            > 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0
           for: 2m
           annotations:
             title: Prometheus Rule Evaluation Failures
@@ -233,8 +252,11 @@ spec:
                     namespace="prometheus-operator"
                   }[10m]
                 )
-              ) * on (namespace, pod) group_left (node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 0.1
           for: 15m
           annotations:
@@ -275,8 +297,11 @@ spec:
                     job="prometheus-operator"
                   }[5m]
                 )
-              ) * on (namespace, pod) group_left (node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 0.1
           for: 15m
           annotations:
@@ -308,8 +333,11 @@ spec:
                   job="prometheus-operator",
                   status="failed"
                 }[5m]
-              ) * on (namespace, pod) group_left (node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) >= 1
           for: 5m
           annotations:
@@ -349,8 +377,11 @@ spec:
                     job="prometheus-operator"
                   }[5m]
                 )
-              ) * on (namespace, pod) group_left (node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 0.1
           for: 10m
           annotations:
@@ -390,8 +421,11 @@ spec:
                     job="prometheus-operator"
                   }[5m]
                 )
-              ) * on (namespace, pod) group_left (node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 0.1
           for: 10m
           annotations:
@@ -420,8 +454,11 @@ spec:
                   namespace="prometheus-operator",
                   job="prometheus-operator"
                 }[5m]
-              ) * on (namespace, pod) group_left (node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 0
           for: 10m
           annotations:
@@ -449,8 +486,11 @@ spec:
                 namespace="prometheus-operator",
                 job="prometheus-operator"
               } == 0
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            )
           for: 5m
           annotations:
             title: >-
@@ -478,8 +518,11 @@ spec:
                 job="prometheus-operator",
                 state="rejected"
               } > 0
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            )
           for: 5m
           annotations:
             title: >-
@@ -507,9 +550,11 @@ spec:
           expr: |-
             increase(
               prometheus_tsdb_checkpoint_creations_failed_total[1m]
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
-            > 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0
           for: 0m
           annotations:
             title: Prometheus TSDB Checkpoint Creation Failures
@@ -530,9 +575,11 @@ spec:
           expr: |-
             increase(
               prometheus_tsdb_checkpoint_deletions_failed_total[1m]
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
-            > 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0
           for: 0m
           annotations:
             title: Prometheus TSDB Checkpoint Creation Failures
@@ -553,9 +600,11 @@ spec:
           expr: |-
             increase(
               prometheus_tsdb_compactions_failed_total[1m]
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
-            > 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0
           for: 0m
           annotations:
             title: Prometheus TSDB Compaction Failures
@@ -576,9 +625,11 @@ spec:
           expr: |-
             increase(
               prometheus_tsdb_head_truncations_failed_total[1m]
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
-            > 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0
           for: 0m
           annotations:
             title: Prometheus TSDB Head Truncation Failures
@@ -599,9 +650,11 @@ spec:
           expr: |-
             increase(
               prometheus_tsdb_reloads_failures_total[1m]
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
-            > 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0
           for: 0m
           annotations:
             title: Prometheus TSDB Reload Failures
@@ -622,9 +675,11 @@ spec:
           expr: |-
             increase(
               prometheus_tsdb_wal_corruptions_total[1m]
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
-            > 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0
           for: 0m
           annotations:
             title: Prometheus TSDB WAL Corruptions
@@ -645,9 +700,11 @@ spec:
           expr: |-
             increase(
               prometheus_tsdb_wal_truncations_failed_total[1m]
-            ) * on (namespace, pod) group_left (node)
-            kube_pod_info
-            > 0
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
+              )
+            ) > 0
           for: 0m
           annotations:
             title: Prometheus TSDB WAL Truncations Failures

--- a/flux/prometheus-rules/workloads.yaml
+++ b/flux/prometheus-rules/workloads.yaml
@@ -19,8 +19,11 @@ spec:
                     kube_pod_container_status_restarts_total[10m]
                   )
                 )
-              ) * on (namespace, pod) group_left (node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 1
           for: 10m
           annotations:
@@ -53,14 +56,16 @@ spec:
                 kube_pod_status_phase{
                   phase!~"Running"
                 }
-              ) * on(namespace, pod)
-                  group_left(owner_kind)
+              ) * on(namespace, pod) group_left(owner_kind)
               max by(namespace, pod, phase, owner_kind) (
                 kube_pod_owner{
                   owner_kind!="Job"
                 }
-              ) * on (namespace, pod) group_left (node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 0
           for: 5m
           annotations:
@@ -84,9 +89,11 @@ spec:
           expr: |-
             sum by (namespace, pod, container, reason) (
               kube_pod_container_status_waiting_reason
-            ) * on(namespace, pod) group_left(node)
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
                 kube_pod_info
-            > 0
+              )
+            ) > 0
           for: 15m
           annotations:
             title: >-
@@ -397,8 +404,11 @@ spec:
                 kube_pod_container_resource_requests{
                   resource="memory"
                 }
-              ) * on(namespace, pod) group_left(node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 1
           for: 3h
           annotations:
@@ -434,8 +444,11 @@ spec:
                 kube_pod_container_resource_limits{
                   resource="memory"
                 }
-              ) * on(namespace, pod) group_left(node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 0.975
           for: 5m
           annotations:
@@ -472,8 +485,11 @@ spec:
                 kube_pod_container_resource_requests{
                   resource="cpu"
                 }
-              ) * on(namespace, pod) group_left(node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 1
           for: 3h
           annotations:
@@ -509,8 +525,11 @@ spec:
                 kube_pod_container_resource_limits{
                   resource="cpu"
                 }
-              ) * on(namespace, pod) group_left(node)
-              kube_pod_info
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
             ) > 0.975
           for: 15m
           annotations:


### PR DESCRIPTION
Refactor the label merge for `kube_pod_info` to `group by() ()` on only required information, which should remove potential duplicate entries on the left-hand side of the `group_left` query. This will resolve when the `kube-state-metrics` service is restarted due to a `Node` or `Deployment` upgrade, which results in new values for some labels, including `instance`, which breaks the mappings.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
