### PR TITLE
Update `Pod` memory requests for multiple services

### DIFF
--- a/flux/cert-manager/cert-manager/cert-manager-values.yaml
+++ b/flux/cert-manager/cert-manager/cert-manager-values.yaml
@@ -183,4 +183,4 @@ cainjector:
       memory: 128Mi
     requests:
       cpu: 10m
-      memory: 64Mi
+      memory: 96Mi

--- a/flux/flux/flux-values.yaml
+++ b/flux/flux/flux-values.yaml
@@ -11,7 +11,7 @@ helmController:
       memory: 128Mi
     requests:
       cpu: 10m
-      memory: 64Mi
+      memory: 96Mi
 
 kustomizeController:
   create: true

--- a/flux/kube-state-metrics/kube-state-metrics-values.yaml
+++ b/flux/kube-state-metrics/kube-state-metrics-values.yaml
@@ -28,7 +28,7 @@ metricLabelsAllowlist:
 
 resources:
   limits: # Don't limit the CPU
-    memory: 64Mi
+    memory: 128Mi
   requests:
     cpu: 10m
-    memory: 32Mi
+    memory: 64Mi

--- a/flux/proxmox-csi/proxmox-csi-values.yaml
+++ b/flux/proxmox-csi/proxmox-csi-values.yaml
@@ -48,6 +48,11 @@ controller:
       requests:
         cpu: 10m
         memory: 64Mi
+  resizer:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
   attacher:
     resources:
       requests:


### PR DESCRIPTION
Based on newly triggered `PodMemoryRequests` alerts, increase the memory requests and limits values for some `Pods` for `cert-manager`, `helm-controller` in Flux, `kube-state-metrics`, and the CSI resizer in `proxmox-csi-plugin`.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
