### PR TITLE
Add notification channel support in Slack

### DIFF
--- a/flux/alertmanager/common.tmpl
+++ b/flux/alertmanager/common.tmpl
@@ -1,98 +1,164 @@
-{{  define "__text_alert_list" }}
-{{-   range . }}
-Labels:
-{{      range .Labels.SortedPairs }}
-  - {{ .Name }} = {{ .Value }}
-{{      end }}
-Annotations:
-{{      range .Annotations.SortedPairs }}
-  - {{ .Name }} = {{ .Value }}
-{{      end }}
-Source: {{ .GeneratorURL }}
-{{    end }}
-{{  end }}
-
-{{ define "custom_single_alert_message" }}
-  {{- "\n" }}
-  {{- range .Firing }}
-    {{- .Annotations.description }}
-  {{- end }}
-  {{- range .Resolved }}
-    {{- .Annotations.description }}
-  {{- end }}
+# Configure the name of this instance of Alertmanager to break down where this
+# alert is being triggered through
+{{  define "common.n3tuk.instance" -}}
+{{-   if .GroupLabels.cluster -}}
+alertmanager ({{ .GroupLabels.cluster }})
+{{-   else -}}
+alertmanager
+{{-   end -}}
 {{- end }}
 
-{{ define "custom_multiple_alerts_message" }}
-  {{- if gt (len .Firing) 0 }}
-  {{- "\n*Alerts Firing:*" }}
-    {{- range .Firing }}
-      {{- "\n  -" }} {{ .Annotations.description }}
-    {{- end }}
-  {{- end }}
-  {{- if gt (len .Resolved) 0 }}
-  {{- "\n*Alerts Resolved:*" }}
-    {{- range .Resolved }}
-      {{- "\n  - " }}{{ .Annotations.description }}
-    {{- end }}
-  {{- end }}
+# Set up the title (or the name, if not provided as an annotation) of the Alert
+# to ensure we focus on the reason why this Alert is being generated
+{{  define "common.n3tuk.title" -}}
+{{-   if .CommonAnnotations.title -}}
+{{-     .CommonAnnotations.title | reReplaceAll "[`*]+" "" -}}
+{{-   else -}}
+{{-     .GroupLabels.alertname -}}
+{{-   end -}}
 {{- end }}
 
-{{ define "custom_slack_message" }}
-  {{- if .CommonAnnotations.summary }}
-    {{- .CommonAnnotations.summary }}
-  {{- end }}
-  {{ template "__alert_severity" . }}
-  {{- if or (and (eq (len .Alerts.Firing) 1) (eq (len .Alerts.Resolved) 0)) (and (eq (len .Alerts.Firing) 0) (eq (len .Alerts.Resolved) 1)) }}
-    {{- template "custom_single_alert_message" .Alerts }}
-  {{- else }}
-    {{- template "custom_multiple_alerts_message" .Alerts }}
-  {{- end }}
+# Extract and provide the name of the Kubernetes Cluster associated with this
+# Alert, working through the Group, Common, and Alert labels, as necessary
+{{  define "common.n3tuk.cluster" }}
+{{-   if .GroupLabels.cluster -}}
+{{-     .GroupLabels.cluster -}}
+{{-   else if .CommonLabels.cluster -}}
+{{-     .CommonLabels.cluster -}}
+{{-   else if (index 0 .Alerts).Labels.cluster -}}
+{{-     (index 0 .Alerts).Labels.cluster -}}
+{{-   else -}}
+unknown
+{{-   end -}}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
-{{ define "__alert_silence_link" -}}
-  {{ .ExternalURL }}/#/silences/new?filter=%7B
-  {{- range .CommonLabels.SortedPairs -}}
-    {{- if ne .Name "alertname" -}}
-      {{- .Name }}%3D"{{- .Value -}}"%2C%20
-    {{- end -}}
-  {{- end -}}
-  alertname%3D"{{ .CommonLabels.alertname }}"%7D
+# Extract and provide the name for the Namespace within the Kubernetes Cluster
+# associated with this Alert, working through the Group, Common, and Alert
+# labels, as necessary
+{{  define "common.n3tuk.namespace" -}}
+{{-   if .GroupLabels.namespace -}}
+{{-     .GroupLabels.namespace -}}
+{{-   else if .CommonLabels.namespace -}}
+{{-     .CommonLabels.namespace -}}
+{{-   else if (index .Alerts 0).Labels.namespace -}}
+{{-     (index .Alerts 0).Labels.namespace -}}
+{{-   else }}unknown{{ end -}}
 {{- end }}
 
-# This builds the run book URL.
-{{ define "__runbook_link" -}}
-  {{- if .CommonAnnotations.runbook }}
-    {{ .CommonAnnotations.runbook }}
-  {{- end }}
+# Extract and provide the Alert Name for this Alert, working through the Group
+# and Alert labels, as necessary
+{{  define "common.n3tuk.alertname" -}}
+{{-   if .GroupLabels.alertname -}}
+{{-     .GroupLabels.alertname -}}
+{{-   else -}}
+{{-     (index .Alerts 0).Labels.alertname -}}
+{{-   end -}}
 {{- end }}
 
-# Allow indication of severity
-{{ define "__alert_severity" -}}
-  {{ if ne .Status "firing" -}}
-  {{- else if eq .CommonLabels.severity "critical" -}}
-  *Severity*: Critical
-  {{- else if eq .CommonLabels.severity "warning" -}}
-  *Severity*: Warning
-  {{- else if eq .CommonLabels.severity "info" -}}
-  *Severity*: Info
-  {{- else -}}
-  *Severity*: :question: ({{ .CommonLabels.severity }})
-  {{- end }}
+# Extract and provide the severity for this Alert, working through the Common,
+# and Alert labels, as necessary
+{{  define "common.n3tuk.severity" -}}
+{{-   if .CommonLabels.severity -}}
+{{-     .CommonLabels.severity | title }}
+{{-   else if (index .Alerts 0).Labels.severity -}}
+{{-     (index .Alerts 0).Labels.severity | title -}}
+{{-   else -}}
+Unknown
+{{-   end -}}
 {{- end }}
 
-{{ define "custom_color" -}}
-  {{ if eq .Status "firing" -}}
-    {{ if eq .CommonLabels.severity "warning" -}}
-      warning
-    {{- else if eq .CommonLabels.severity "critical" -}}
-      danger
-    {{- else -}}
-      #439FE0
-    {{- end -}}
-  {{ else -}}
-    good
-  {{- end }}
+# Extract and provide the time since the initial firing of the first Alert
+{{  define "common.n3tuk.since" -}}
+{{-   (index .Alerts 0).StartsAt | since | humanizeDuration -}}
+{{- end }}
+
+# Generate the Runbook URL to link to the provided runbook which can be attached
+# to the Alerts for additional context, with the default being a fallback to the
+# central Runbooks section of the Lab Environment documentation website
+{{  define "common.n3tuk.runbook" -}}
+{{-   if .CommonAnnotations.runbook -}}
+{{-     .CommonAnnotations.runbook -}}
+{{-   else if (index .Alerts 0).Annotations.runbook -}}
+{{-     (index .Alerts 0).Annotations.runbook -}}
+{{-   else -}}
+https://d.n3t.uk/runbooks/
+{{-   end -}}
+{{- end }}
+
+# Generate the Dashboard URL to the provided Grafana dashboard which can be
+# attached to the Alerts for additional context, with the default being a
+# fallback to the Grafana instance of the local Kubernetes Cluster
+{{  define "common.n3tuk.dashboard" -}}
+{{-   if .CommonAnnotations.dashboard -}}
+{{-     .CommonAnnotations.dashboard -}}
+{{-   else if (index .Alerts 0).Annotations.dashboard -}}
+{{-     (index .Alerts 0).Annotations.dashboard -}}
+{{-   else -}}
+{{-     if .GroupLabels.cluster -}}
+https://grafana.{{ .GroupLabels.cluster | reReplaceAll "^([a-z]).*$" "$1" }}.kub3.uk/
+{{-     else -}}
+https://grafana.p.kub3.uk/
+{{-     end -}}
+{{-   end -}}
+{{- end }}
+
+# Generate the Prometheus URL to link to the Prometheus Query which monitors the
+# metrics and therefore created the Alert so the data can be reviewed
+{{  define "common.n3tuk.prometheus_query_link" -}}
+{{-   (index .Alerts 0).GeneratorURL -}}
+{{- end }}
+
+# Generate the Prometheus URL to link to the Prometheus Alerts page with the
+# focus on the Prometheus Rule for this Alert, showing all related Alerts
+{{  define "common.n3tuk.prometheus_alerts_link" -}}
+{{-   (index .Alerts 0).GeneratorURL | reReplaceAll "^([^\\?]+)/query\\?.*$" "$1/alerts?" -}}
+search%3D{{ .GroupLabels.alertname -}}
+{{- end }}
+
+# Generate the Alertmanager URL to link to the firing Alerts in Alertmanager
+# using the labels used to group the Alerts as the filter, ensuring only this
+# Alert, and any related Alerts, are shown (including those silenced)
+{{  define "common.n3tuk.alertmanager_link" -}}
+{{-   .ExternalURL }}/#/alerts?silenced=true&active=true&filter=%7B
+{{-   range .GroupLabels.SortedPairs -}}
+{{-     if ne .Name "alertname" -}}
+{{-       .Name }}%3D%22{{ .Value }}%22%2C
+{{-     end -}}
+{{-   end -}}
+alertname%3D%22{{ .GroupLabels.alertname }}%22%7D
+{{- end }}
+
+# Generate the Alertmanager URL to create the silence override, combining the
+# labels used to group these Alerts as the filter to allow the silencing of this
+# and all other related Alerts in Alertmanager
+{{  define "common.n3tuk.silence_all_link" -}}
+{{-   .ExternalURL }}/#/silences/new?filter=%7B
+{{-   range .GroupLabels.SortedPairs -}}
+{{-     if ne .Name "alertname" -}}
+{{-       .Name }}%3D%22{{ .Value }}%22%2C
+{{-     end -}}
+{{-   end -}}
+alertname%3D%22{{ .GroupLabels.alertname }}%22%7D
+{{- end }}
+
+# Generate the Alertmanager URL to create the silence override, combining the
+# labels used to group the Alerts, as well as a selected of the common labels
+# from all the alerts (as many of the labels are related to the metrics
+# collection and not the context or environment of the alert), into a filter to
+# allow the silencing of this single Alert
+{{  define "common.n3tuk.silence_single_link" -}}
+{{-   .ExternalURL }}/#/silences/new?filter=%7B
+{{-   range .GroupLabels.SortedPairs -}}
+{{-     if ne .Name "alertname" -}}
+{{-       .Name }}%3D%22{{ .Value }}%22%2C
+{{-     end -}}
+{{-   end -}}
+alertname%3D%22{{ .GroupLabels.alertname }}%22
+{{-   if .CommonLabels.node }}2Cnode%3D%22{{ .CommonLabels.node }}%22{{ end -}}
+{{-   if .CommonLabels.job }}2Cjob%3D%22{{ .CommonLabels.job }}%22{{ end -}}
+{{-   if .CommonLabels.pod }}2Cpod%3D%22{{ .CommonLabels.pod }}%22{{ end -}}
+{{-   if .CommonLabels.container }}2Ccontainer%3D%22{{ .CommonLabels.container }}%22{{ end -}}
+{{-   if .CommonLabels.name }}2Cname%3D%22{{ .CommonLabels.name }}%22{{ end -}}
+{{-   if .CommonLabels.severity }}2Cseverity%3D%22{{ .CommonLabels.severity }}%22{{ end -}}
+%7D
 {{- end }}

--- a/flux/alertmanager/incidentio.yaml
+++ b/flux/alertmanager/incidentio.yaml
@@ -15,7 +15,7 @@ spec:
       - name: incidentio
         matchType: '!='
         value: ignore
-    repeatInterval: 1m
+    repeatInterval: 5m
     continue: true
 
   receivers:

--- a/flux/alertmanager/pagerduty.tmpl
+++ b/flux/alertmanager/pagerduty.tmpl
@@ -1,28 +1,6 @@
-{{/* Configure the client name for the message provided to PagerDuty, which
-     should provide the information on where it is being triggered from */}}
-{{  define "pagerduty.n3tuk.client" -}}
-alertmanager ({{ .GroupLabels.cluster }})
-{{- end }}
-
-{{/* Configure the client URL for the message provided to PagerDuty, which
-     should provide the link to the Alert it is being triggered from */}}
-{{  define "pagerduty.n3tuk.client_url" -}}
-{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver | urlquery }}
-{{- end }}
-
-{{/* Set up the title (or Alert name) for the message to be provided to
-     PagerDuty, as this is used for the title of the event in PagerDuty */}}
-{{  define "pagerduty.n3tuk.title" -}}
-{{-   if .CommonAnnotations.title -}}
-{{-     .CommonAnnotations.title | reReplaceAll "[`*]+" "" -}}
-{{-   else -}}
-{{-     .GroupLabels.alertname -}}
-{{-   end -}}
-{{- end }}
-
-{{/* Set up the (or summary) for the message to be provided to PagerDuty,
-     which should use the summary of the Alert, where possible, not the full
-     description, as this is used for the title of the event in PagerDuty */}}
+# Set up the (or summary) for the message to be provided to PagerDuty, which
+# should use the summary of the Alert, where possible, not the full description,
+# as this is used for the title of the event in PagerDuty
 {{  define "pagerduty.n3tuk.summary" -}}
 {{-   if .CommonAnnotations.summary -}}
 {{-     .CommonAnnotations.summary | reReplaceAll "[`*]+" "" -}}
@@ -31,63 +9,9 @@ No common summary is available for this event. See the individual descriptions f
 {{-   end -}}
 {{- end }}
 
-{{/* Set up the value for the priority for the PagerDuty event, which
-     should be based on the label provided for each Alert */}}
-{{  define "pagerduty.n3tuk.priority" -}}
-{{-   if .CommonLabels.pagerduty -}}
-{{-     .CommonLabels.pagerduty -}}
-{{-   else if (index .Alerts 0).Labels.pagerduty -}}
-{{-     (index .Alerts 0).Labels.pagerduty -}}
-{{-   else }}P5{{ end -}}
-{{- end }}
-
-{{/* Set up the value for the severity field for the PagerDuty event, which
-     should be based on the label provided for each Alert */}}
-{{  define "pagerduty.n3tuk.severity" -}}
-{{-   if .CommonLabels.severity -}}
-{{-     .CommonLabels.severity -}}
-{{-   else if (index .Alerts 0).Labels.severity -}}
-{{-     (index .Alerts 0).Labels.severity -}}
-{{-   else }}P5{{ end -}}
-{{- end }}
-
-{{/* Set up the value for the Alert Name field for the PagerDuty event, which
-     should be based on the label provided for each Alert */}}
-{{  define "pagerduty.n3tuk.alert_name" -}}
-{{-   if .GroupLabels.alertname -}}
-{{-     .GroupLabels.alertname -}}
-{{-   else -}}
-{{-     (index .Alerts 0).Labels.alertname -}}
-{{-   end -}}
-{{- end }}
-
-{{/* Set up the value for the Cluster field for the PagerDuty event, which
-     should be based on the label provided for each Alert */}}
-{{  define "pagerduty.n3tuk.cluster" -}}
-{{-   if .GroupLabels.cluster -}}
-{{-     .GroupLabels.cluster -}}
-{{-   else if .CommonLabels.cluster -}}
-{{-     .CommonLabels.cluster -}}
-{{-   else if (index .Alerts 0).Labels.cluster -}}
-{{-     (index .Alerts 0).Labels.cluster -}}
-{{-   else }}unknown{{ end -}}
-{{- end }}
-
-{{/* Set up the value for the Namespace field for the PagerDuty event, which
-     should be based on the label provided for each Alert */}}
-{{  define "pagerduty.n3tuk.namespace" -}}
-{{-   if .GroupLabels.namespace -}}
-{{-     .GroupLabels.namespace -}}
-{{-   else if .CommonLabels.namespace -}}
-{{-     .CommonLabels.namespace -}}
-{{-   else if (index .Alerts 0).Labels.namespace -}}
-{{-     (index .Alerts 0).Labels.namespace -}}
-{{-   else }}unknown{{ end -}}
-{{- end }}
-
-{{/* Provide a list of full descriptions for all the Alerts currently firing or
-     resolved within this event, to provide additional detail for each one over
-     and above the summary and title (or Alert name) already provided */}}
+# Provide a list of full descriptions for all the Alerts currently firing or
+# resolved within this event, to provide additional detail for each one over and
+# above the summary and title (or Alert name) already provided
 {{  define "pagerduty.n3tuk.firing" -}}
 {{-   $commonSummary := false }}
 {{-   if .CommonAnnotations.summary -}}
@@ -115,7 +39,7 @@ This Alert has no description
 {{-   if .CommonAnnotations.summary -}}
 {{-     $commonSummary = true -}}
 {{-   end -}}
-{{-   if eq (len .Alerts.resolved) 0 -}}
+{{-   if eq (len .Alerts.Resolved) 0 -}}
 (none)
 {{-   else -}}
 {{-     range .Alerts.Resolved -}}
@@ -130,28 +54,4 @@ This Alert has no description
 {{-       print " " }}({{ .StartsAt | since | humanizeDuration }} ago)
 {{      end -}}
 {{-   end -}}
-{{- end }}
-
-{{/* Provide a Runbook link for this Alert/Event */}}
-{{  define "pagerduty.n3tuk.runbook" -}}
-{{-   if .CommonAnnotations.runbook }}
-{{      .CommonAnnotations.runbook }}
-{{-   else if (index .Alerts 0).Annotations.runbook }}
-{{      (index .Alerts 0).Annotations.runbook }}
-{{-   else -}}
-        https://d.n3t.uk/runbooks/
-{{-   end }}
-{{- end }}
-
-{{/* Provide a Dashboard link for this Alert/Event, but the default of which is
-     templated to the Production Grafana instance as this file cannot be
-     templated through Flux's Kustomization */}}
-{{  define "pagerduty.n3tuk.dashboard" -}}
-{{-   if .CommonAnnotations.dashboard }}
-{{      .CommonAnnotations.dashboard }}
-{{-   else if (index .Alerts 0).Annotations.dashboard }}
-{{      (index .Alerts 0).Annotations.dashboard }}
-{{-   else -}}
-        https://grafana.p.kub3.uk/
-{{-   end }}
 {{- end }}

--- a/flux/alertmanager/pagerduty.yaml
+++ b/flux/alertmanager/pagerduty.yaml
@@ -26,34 +26,31 @@ spec:
             key: service-key
           sendResolved: true
           client: >-
-            {{ template "pagerduty.n3tuk.client" . }}
+            {{ template "common.n3tuk.instance" . }}
           clientURL: >-
-            {{ template "pagerduty.n3tuk.client_url" . }}
+            {{ template "common.n3tuk.alertmanager_link" . }}
           description: >-
-            {{ template "pagerduty.n3tuk.title" . }}
+            {{ template "common.n3tuk.title" . }}
           severity: >-
-            {{ template "pagerduty.n3tuk.priority" . }}
+            {{ template "common.n3tuk.severity" . }}
           source: >-
-            {{ template "pagerduty.n3tuk.username" . }}
+            {{ template "common.n3tuk.instance" . }}
           details:
             - key: alert name
               value: >-
-                {{ template "pagerduty.n3tuk.alert_name" . }}
+                {{ template "common.n3tuk.alertname" . }}
             - key: summary
               value: >-
                 {{ template "pagerduty.n3tuk.summary" . }}
-            - key: priority
-              value: >-
-                {{ template "pagerduty.n3tuk.priority" . }}
             - key: cluster
               value: >-
-                {{ template "pagerduty.n3tuk.cluster" . }}
+                {{ template "common.n3tuk.cluster" . }}
             - key: namespace
               value: >-
-                {{ template "pagerduty.n3tuk.namespace" . }}
+                {{ template "common.n3tuk.namespace" . }}
             - key: severity
               value: >-
-                {{ template "pagerduty.n3tuk.severity" . }}
+                {{ template "common.n3tuk.severity" . }}
             - key: firing
               value: >-
                 {{ template "pagerduty.n3tuk.firing" . }}
@@ -61,20 +58,26 @@ spec:
               value: >-
                 {{ template "pagerduty.n3tuk.resolved" . }}
           pagerDutyLinkConfigs:
-            - alt: Runbooks
+            - alt: Prometheus Query
               href: >-
-                {{ template "pagerduty.n3tuk.runbook" . }}
-            - alt: Dashboard
+                {{ template "common.n3tuk.prometheus_query_link" . }}
+            - alt: Prometheus Alerts
               href: >-
-                {{ template "pagerduty.n3tuk.dashboard" . }}
-            - alt: Prometheus
+                {{ template "common.n3tuk.prometheus_alert_link" . }}
+            - alt: Alertmanager Alerts
               href: >-
-                {{ (index .Alerts 0).GeneratorURL }}
-            - alt: Alertmanager
+                {{ template "common.n3tuk.alertmanager_link" . }}
+            - alt: Grafana Dashboard
               href: >-
-                https://alerts.${cluster_domain}/
-            - alt: Silence
+                {{ template "common.n3tuk.dashboard" . }}
+            - alt: Review the Runbook
               href: >-
-                {{ template "__alert_silence_link" . }}
+                {{ template "common.n3tuk.runbook" . }}
+            - alt: Silence this Alert
+              href: >-
+                {{ template "common.n3tuk.silence_single_link" . }}
+            - alt: Silence all Alerts
+              href: >-
+                {{ template "common.n3tuk.silence_all_link" . }}
           component: kub3-${cluster}
           group: ${cluster}

--- a/flux/alertmanager/slack.tmpl
+++ b/flux/alertmanager/slack.tmpl
@@ -1,5 +1,5 @@
-{{/* Define the Slack Channel to send the Alert to based on the provided labels
-     to either all of the alerts (if common), or the first Alert, if set */}}
+# Define the Slack Channel to send the Alert to based on the provided labels to
+# either all of the alerts (if common), or the first Alert, if set
 {{  define "slack.n3tuk.channel" }}
 {{-   if ne .CommonLabels.slack "" -}}
 {{-      print "#" .CommonLabels.slack -}}
@@ -10,9 +10,9 @@
 {{-   end -}}
 {{- end }}
 
-{{/* Configure the colour of the sidebar of the message provided to Slack, which
-     mainly depends if the Alert is firing or not */}}
-{{  define "slack.n3tuk.color" }}
+# Configure the colour of the sidebar of the message provided to Slack, which
+# mainly depends if the Alert is firing or not
+{{  define "slack.n3tuk.color" -}}
 {{-   if eq .Status "firing" -}}
 {{-     if eq .CommonLabels.severity "critical" -}}
           danger
@@ -26,43 +26,25 @@
 {{-   end -}}
 {{- end }}
 
-{{/* Configure the username for the message provided to Slack, which should
-     provide the information on where it is being triggered from */}}
-{{  define "slack.n3tuk.username" -}}
-alertmanager ({{ .CommonLabels.cluster }})
-{{- end }}
-
-{{/* Set up the title (or summary) for the message to be provided to Slack,
-     which should usually be the title annotation of the Alert, falling back to
-     the name of the Alert if that is not available (Slack does not yet support
-     Markdown in the title of the block, so it is filtered out here) */}}
-{{  define "slack.n3tuk.title" -}}
-{{-   if .CommonAnnotations.title -}}
-{{-     .CommonAnnotations.title | reReplaceAll "[`*]+" "" -}}
-{{-   else -}}
-{{-     .GroupLabels.alertname -}}
-{{-   end -}}
-{{- end }}
-
-{{/* Provide a primary link which can be used either with the title of a
-     message, or with the basic Slack message when the client cannot show
-     formatted text (usually when the message as shown as a notification rather
-     than within the application itself), and so prioritise the link to use
-     based a number of on possible options */}}
+# Provide a primary link which can be used either with the title of a message,
+# or with the basic Slack message when the client cannot show formatted text
+# (usually when the message as shown as a notification rather than within the
+# application itself), and so prioritise the link to use based a number of on
+# possible options
 {{  define "slack.n3tuk.link" -}}
 {{-   if .CommonAnnotations.link -}}
-        {{ .CommonAnnotations.link }}
+{{-     .CommonAnnotations.link -}}
 {{-   else if .CommonAnnotations.dashboard -}}
-        {{ .CommonAnnotations.dashboard }}
+{{-     .CommonAnnotations.dashboard -}}
 {{-   else if .CommonAnnotations.runbook -}}
-        {{ .CommonAnnotations.runbook }}
+{{-     .CommonAnnotations.runbook -}}
 {{-   else -}}
-        {{ (index .Alerts 0).GeneratorURL }}
+{{-     template "common.n3tuk.alertmanager_link" . -}}
 {{-   end -}}
 {{- end }}
 
-{{/* Provide the pre-text to send with the Slack message which provides
-     information about the number of Alerts contained within this message */}}
+# Provide the pre-text to send with the Slack message which provides information
+# about the number of Alerts contained within this message
 {{  define "slack.n3tuk.pretext" -}}
 {{-   if and (gt (len .Firing) 0) (gt (len .Resolved) 0) -}}
 Alertmanager is reporting *{{ len .Firing }}* alert{{ if ne (len .Firing) 1 }}s{{ end }} as firing, plus *{{ len .Resolved }}* alert{{ if ne (len .Resolved) 1 }}s{{ end }} as resolved.
@@ -73,9 +55,9 @@ Alertmanager is reporting *{{ len .Resolved }}* alert{{ if ne (len .Resolved) 1 
 {{-   end -}}
 {{- end }}
 
-{{/* Provide the description (or message) to send with the Slack message on the
-     Alert, and more specifically handle Alerts firing and resolving, as well
-     as different descriptions for the Alerts, where configured. */}}
+# Provide the description (or message) to send with the Slack message on the
+# Alert, and more specifically handle Alerts firing and resolving, as well as
+# different descriptions for the Alerts, where configured.
 {{  define "slack.n3tuk.text" -}}
 {{-   $commonSummary := false -}}
 {{-   if .CommonAnnotations.summary -}}
@@ -111,13 +93,13 @@ This `Alert` has no description
 {{        if not $commonSummary -}}){{ end -}}
 {{- print " " }}(_{{ .EndsAt | since | humanizeDuration }} ago_)
 {{-     end -}}
-{{-   end -}}
-{{- end }}
+{{-   end }}
+{{  end }}
 
-{{/* Provide the fallback message for Slack, which is often used for the
-     notification of the message across devices */}}
+# Provide the fallback message for Slack, which is often used for the
+# notification of the message across devices
 {{  define "slack.n3tuk.fallback" -}}
-{{    template "slack.n3tuk.title" . }} ({{ .Status | title }})
+{{-   template "common.n3tuk.title" . }} ({{ .Status | title }})
 {{    if .CommonAnnotations.summary -}}
 {{-     .CommonAnnotations.summary -}}
 {{-   else -}}
@@ -131,48 +113,8 @@ Alertmanager is reporting *{{ len .Resolved }}* alert{{ if ne (len .Resolved) 1 
 {{-   end -}}
 {{- end }}
 
-{{/* Provide the name of the Cluster for this Alert, working through the
-     Group, Common, and Alert labels, as necessary */}}
-{{  define "slack.n3tuk.cluster" }}
-{{-   if .GroupLabels.cluster -}}
-{{-     .GroupLabels.cluster -}}
-{{-   else if .CommonLabels.cluster -}}
-{{-     .CommonLabels.cluster -}}
-{{-   else if (index 0 .Alerts).Labels.cluster -}}
-{{-     (index 0 .Alerts).Labels.cluster -}}
-{{-   else -}}
--
-{{-   end -}}
-{{- end }}
-
-{{/* Provide the name of the Namespace for this Alert, working through the
-     Group, Common, and Alert labels, as necessary */}}
-{{  define "slack.n3tuk.namespace" }}
-{{-   if .GroupLabels.namespace -}}
-{{-     .GroupLabels.namespace }}
-{{-   else if .CommonLabels.namespace -}}
-{{-     .CommonLabels.namespace }}
-{{-   else if (index 0 .Alerts).Labels.namespace -}}
-{{-     (index 0 .Alerts).Labels.namespace -}}
-{{-   else -}}
--
-{{-   end -}}
-{{- end }}
-
-{{/* Provide the value for the severity for this Alert, working through the
-     Common, and Alert labels, as necessary */}}
-{{  define "slack.n3tuk.severity" }}
-{{  if .CommonLabels.severity -}}
-{{    .CommonLabels.severity | title }}
-{{- else if (index .Alerts 0).Labels.severity }}
-{{    (index .Alerts 0).Labels.severity | title }}
-{{- else -}}
-Unknown
-{{- end }}
-{{- end }}
-
-{{/* Provide the footer of the message for Slack, which is normally used to
-     provide useful contextual information */}}
+# Provide the footer of the message for Slack, which is normally used to provide
+# useful contextual information
 {{  define "slack.n3tuk.footer" -}}
 This Alert was generated by Alertmanager {{ if .CommonLabels.prometheus -}}
 and the {{ .CommonLabels.prometheus }} Prometheus instance {{ end -}}

--- a/flux/alertmanager/slack.yaml
+++ b/flux/alertmanager/slack.yaml
@@ -46,9 +46,9 @@ spec:
           color: >-
             {{ template "slack.n3tuk.color" . }}
           username: >-
-            {{ template "slack.n3tuk.username" . }}
+            {{ template "common.n3tuk.instance" . }}
           title: >-
-            {{ template "slack.n3tuk.title" . }}
+            {{ template "common.n3tuk.title" . }}
           titleLink: >-
             {{ template "slack.n3tuk.link" . }}
           pretext: |
@@ -62,41 +62,46 @@ spec:
           fields:
             - title: Alert Name
               value: >-
-                {{ .GroupLabels.alertname }}
+                {{ template "common.n3tuk.alertname" . }}
               short: false
             - title: Cluster
               value: >-
-                {{ template "slack.n3tuk.cluster" . }}
+                {{ template "common.n3tuk.cluster" . }}
               short: true
             - title: Namespace
               value: >-
-                {{ template "slack.n3tuk.namespace" . }}
+                {{ template "common.n3tuk.namespace" . }}
               short: true
             - title: Severity
               value: >-
-                {{ template "slack.n3tuk.severity" . }}
+                {{ template "common.n3tuk.severity" . }}
               short: true
             - title: Since
               value: >-
-                {{ (index .Alerts 0).StartsAt | since | humanizeDuration }}
+                {{ template "common.n3tuk.since" . }}
               short: true
           actions:
+            # Maximum of five actions allowed?
+            - text: Prometheus Query
+              type: button
+              url: >-
+                {{ template "common.n3tuk.prometheus_query_link" . }}
+            - text: Alertmanager Alerts
+              type: button
+              url: >-
+                {{ template "common.n3tuk.alertmanager_link" . }}
+            - text: Grafana Dashboard
+              type: button
+              url: >-
+                {{ template "common.n3tuk.dashboard" . }}
             - text: Runbook
               type: button
               url: >-
-                {{ (index .Alerts 0).Annotations.runbook }}
-            - text: Query
+                {{ template "common.n3tuk.runbook" . }}
+            - text: Silence Alert
               type: button
               url: >-
-                {{ (index .Alerts 0).GeneratorURL }}
-            - text: Dashboard
-              type: button
-              url: >-
-                {{ (index .Alerts 0).Annotations.dashboard }}
-            - text: Silence
-              type: button
-              url: >-
-                {{ template "__alert_silence_link" . }}
+                {{ template "common.n3tuk.silence_all_link" . }}
           linkNames: false
           mrkdwnIn:
             - title
@@ -117,9 +122,9 @@ spec:
           color: >-
             {{ template "slack.n3tuk.color" . }}
           username: >-
-            {{ template "slack.n3tuk.username" . }}
+            {{ template "common.n3tuk.instance" . }}
           title: >-
-            {{ template "slack.n3tuk.title" . }}
+            {{ template "common.n3tuk.title" . }}
           titleLink: >-
             {{ template "slack.n3tuk.link" . }}
           pretext: |
@@ -133,41 +138,45 @@ spec:
           fields:
             - title: Alert Name
               value: >-
-                {{ .GroupLabels.alertname }}
+                {{ template "common.n3tuk.alertname" . }}
               short: false
             - title: Cluster
               value: >-
-                {{ template "slack.n3tuk.cluster" . }}
+                {{ template "common.n3tuk.cluster" . }}
               short: true
             - title: Namespace
               value: >-
-                {{ template "slack.n3tuk.namespace" . }}
+                {{ template "common.n3tuk.namespace" . }}
               short: true
             - title: Severity
               value: >-
-                {{ template "slack.n3tuk.severity" . }}
+                {{ template "common.n3tuk.severity" . }}
               short: true
             - title: Since
               value: >-
-                {{ (index .Alerts 0).StartsAt | since | humanizeDuration }}
+                {{ template "common.n3tuk.since" . }}
               short: true
           actions:
+            - text: Prometheus Query
+              type: button
+              url: >-
+                {{ template "common.n3tuk.prometheus_query_link" . }}
+            - text: Alertmanager Alerts
+              type: button
+              url: >-
+                {{ template "common.n3tuk.alertmanager_link" . }}
+            - text: Grafana Dashboard
+              type: button
+              url: >-
+                {{ template "common.n3tuk.dashboard" . }}
             - text: Runbook
               type: button
               url: >-
-                {{ (index .Alerts 0).Annotations.runbook }}
-            - text: Query
+                {{ template "common.n3tuk.runbook" . }}
+            - text: Silence Alert
               type: button
               url: >-
-                {{ (index .Alerts 0).GeneratorURL }}
-            - text: Dashboard
-              type: button
-              url: >-
-                {{ (index .Alerts 0).Annotations.dashboard }}
-            - text: Silence
-              type: button
-              url: >-
-                {{ template "__alert_silence_link" . }}
+                {{ template "common.n3tuk.silence_all_link" . }}
           linkNames: false
           mrkdwnIn:
             - title
@@ -188,9 +197,9 @@ spec:
           color: >-
             {{ template "slack.n3tuk.color" . }}
           username: >-
-            {{ template "slack.n3tuk.username" . }}
+            {{ template "common.n3tuk.instance" . }}
           title: >-
-            {{ template "slack.n3tuk.title" . }}
+            {{ template "common.n3tuk.title" . }}
           titleLink: >-
             {{ template "slack.n3tuk.link" . }}
           pretext: |
@@ -204,41 +213,120 @@ spec:
           fields:
             - title: Alert Name
               value: >-
-                {{ .GroupLabels.alertname }}
+                {{ template "common.n3tuk.alertname" . }}
               short: false
             - title: Cluster
               value: >-
-                {{ template "slack.n3tuk.cluster" . }}
+                {{ template "common.n3tuk.cluster" . }}
               short: true
             - title: Namespace
               value: >-
-                {{ template "slack.n3tuk.namespace" . }}
+                {{ template "common.n3tuk.namespace" . }}
               short: true
             - title: Severity
               value: >-
-                {{ template "slack.n3tuk.severity" . }}
+                {{ template "common.n3tuk.severity" . }}
+              short: true
+            - title: Since
+              value: >-
+                {{ template "common.n3tuk.since" . }}
+              short: true
+          actions:
+            - text: Prometheus Query
+              type: button
+              url: >-
+                {{ template "common.n3tuk.prometheus_query_link" . }}
+            - text: Alertmanager Alerts
+              type: button
+              url: >-
+                {{ template "common.n3tuk.alertmanager_link" . }}
+            - text: Grafana Dashboard
+              type: button
+              url: >-
+                {{ template "common.n3tuk.dashboard" . }}
+            - text: Runbook
+              type: button
+              url: >-
+                {{ template "common.n3tuk.runbook" . }}
+            - text: Silence Alert
+              type: button
+              url: >-
+                {{ template "common.n3tuk.silence_all_link" . }}
+          linkNames: false
+          mrkdwnIn:
+            - title
+            - pretext
+            - text
+
+    - name: notifications
+      slackConfigs:
+        - apiURL:
+            name: slack-webhooks
+            key: notifications
+          httpConfig: {}
+          channel: '#kub3-${cluster}-notifications'
+          sendResolved: true
+          shortFields: false
+          iconEmoji: ':alertmanager:'
+          iconURL: https://alerts.${cluster_domain}/
+          color: >-
+            {{ template "slack.n3tuk.color" . }}
+          username: >-
+            {{ template "common.n3tuk.instance" . }}
+          title: >-
+            {{ template "common.n3tuk.title" . }}
+          titleLink: >-
+            {{ template "slack.n3tuk.link" . }}
+          pretext: |
+            {{ template "slack.n3tuk.pretext" .Alerts }}
+          text: |
+            {{ template "slack.n3tuk.text" . }}
+          footer: |
+            {{ template "slack.n3tuk.footer" . }}
+          fallback: >-
+            {{ template "slack.n3tuk.fallback" . }}
+          fields:
+            - title: Alert Name
+              value: >-
+                {{ template "common.n3tuk.alertname" . }}
+              short: false
+            - title: Cluster
+              value: >-
+                {{ template "common.n3tuk.cluster" . }}
+              short: true
+            - title: Namespace
+              value: >-
+                {{ template "common.n3tuk.namespace" . }}
+              short: true
+            - title: Severity
+              value: >-
+                {{ template "common.n3tuk.severity" . }}
               short: true
             - title: Since
               value: >-
                 {{ (index .Alerts 0).StartsAt | since | humanizeDuration }}
               short: true
           actions:
+            - text: Prometheus Query
+              type: button
+              url: >-
+                {{ template "common.n3tuk.prometheus_query_link" . }}
+            - text: Alertmanager Alerts
+              type: button
+              url: >-
+                {{ template "common.n3tuk.alertmanager_link" . }}
+            - text: Grafana Dashboard
+              type: button
+              url: >-
+                {{ template "common.n3tuk.dashboard" . }}
             - text: Runbook
               type: button
               url: >-
-                {{ (index .Alerts 0).Annotations.runbook }}
-            - text: Query
+                {{ template "common.n3tuk.runbook" . }}
+            - text: Silence Alert
               type: button
               url: >-
-                {{ (index .Alerts 0).GeneratorURL }}
-            - text: Dashboard
-              type: button
-              url: >-
-                {{ (index .Alerts 0).Annotations.dashboard }}
-            - text: Silence
-              type: button
-              url: >-
-                {{ template "__alert_silence_link" . }}
+                {{ template "common.n3tuk.silence_all_link" . }}
           linkNames: false
           mrkdwnIn:
             - title

--- a/flux/alertmanager/slack.yaml
+++ b/flux/alertmanager/slack.yaml
@@ -28,6 +28,11 @@ spec:
             matchType: =
             value: kub3-${cluster}-alerts-applications
         continue: true
+      - receiver: notifications
+        matchers:
+          - name: slack
+            value: kub3-${cluster}-notifications
+        continue: true
     repeatInterval: 3h
     continue: true
 

--- a/flux/cert-manager/cert-manager/cert-manager-values.yaml
+++ b/flux/cert-manager/cert-manager/cert-manager-values.yaml
@@ -147,9 +147,11 @@ cainjector:
     minAvailable: 1
 
   resources:
+    limits: # Don't limit the CPU
+      memory: 128Mi
     requests:
-      cpu: 5m
-      memory: 64Mi
+      cpu: 10m
+      memory: 96Mi
 
   topologySpreadConstraints:
     - maxSkew: 1
@@ -176,11 +178,3 @@ startupapicheck:
     requests:
       cpu: 10m
       memory: 32Mi
-
-cainjector:
-  resources:
-    limits: # Don't limit the CPU
-      memory: 128Mi
-    requests:
-      cpu: 10m
-      memory: 96Mi

--- a/flux/elastic-logs/prometheus-rules.yaml
+++ b/flux/elastic-logs/prometheus-rules.yaml
@@ -148,7 +148,7 @@ spec:
 
     - name: elasticsearch-shards
       rules:
-        - alert: ElasticSearchRelocatingShardsInfo
+        - alert: ElasticSearchRelocatingShardsNotice
           expr: |-
             elasticsearch_cluster_health_relocating_shards{
               namespace="elastic-logs",
@@ -161,15 +161,15 @@ spec:
             title: ElasticSearch Cluster is Relocating Shards
             summary: >-
               One or more ElasticSearch clusters in the `{{$externalLabels.cluster}}` Cluster have
-              reported *they are relocating shards across the* `data` *nodes*, which can degrate the
-              cluster's performance.
+              reported *they are relocating shards across the* `data` *nodes*, which can temporarily
+              degrate the cluster's performance.
             description: >-
               `{{$labels.namespace}}`/`{{$labels.cluster}}` Cluster (*{{$value|humanize}}* nodes)
             runbook: https://d.n3t.uk/runbooks/
           labels:
-            ignore: outside-extended-hours
+            ignore: never
             severity: info
-            slack: kub3-${cluster}-alerts-infra
+            slack: kub3-${cluster}-notifications
             pagerduty: ignore
             incidentio: ignore
             team: platform
@@ -199,7 +199,7 @@ spec:
             incidentio: send
             team: platform
 
-        - alert: ElasticSearchInitializingShardsInfo
+        - alert: ElasticSearchInitializingShardsNotice
           expr: |-
             elasticsearch_cluster_health_initializing_shards{
               namespace="elastic-logs",
@@ -217,13 +217,12 @@ spec:
               `{{$labels.namespace}}`/`{{$labels.cluster}}` Cluster (*{{$value|humanize}}* shards)
             runbook: https://d.n3t.uk/runbooks/
           labels:
-            ignore: outside-extended-hours
+            ignore: never
             severity: info
-            slack: kub3-${cluster}-alerts-infra
+            slack: kub3-${cluster}-notifications
             pagerduty: ignore
             incidentio: ignore
             team: platform
-            runbook: https://d.n3t.uk/runbooks/
 
         - alert: ElasticSearchInitializingShardsWarning
           expr: |-

--- a/flux/prometheus-rules/prometheus.yaml
+++ b/flux/prometheus-rules/prometheus.yaml
@@ -725,7 +725,7 @@ spec:
           expr: |-
             sum(
               sum_over_time(
-                scrape_series_added[3h]
+                scrape_series_added[1h]
               )
             ) > (
               0.01 *

--- a/flux/prometheus-rules/prometheus.yaml
+++ b/flux/prometheus-rules/prometheus.yaml
@@ -753,14 +753,14 @@ spec:
             description: >-
               *{{$value|humanize}}* metrics added
           labels:
-            ignore: outside-extended-hours
+            ignore: never
             severity: info
-            slack: kub3-${cluster}-alerts-infra
+            slack: kub3-${cluster}-notifications
             pagerduty: ignore
             incidentio: ignore
             team: platform
 
-        - alert: PrometheusTSDBSeriesCardinalityWarning
+        - alert: PrometheusTSDBSeriesCardinalityNotice
           expr: |-
             label_replace(
               topk(
@@ -781,9 +781,9 @@ spec:
             description: >-
               `{{$labels.name}}` (*{{$value|humanize}}* labels)
           labels:
-            ignore: outside-extended-hours
-            severity: warning
-            slack: kub3-${cluster}-alerts-infra
-            pagerduty: send
-            incidentio: create
+            ignore: never
+            severity: info
+            slack: kub3-${cluster}-notifications
+            pagerduty: ignore
+            incidentio: ignore
             team: platform

--- a/flux/prometheus-rules/workloads.yaml
+++ b/flux/prometheus-rules/workloads.yaml
@@ -361,9 +361,9 @@ spec:
               `{{$labels.cronjob}}` `CronJob`
             runbook: https://d.n3t.uk/runbooks/
           labels:
-            ignore: outside-extended-hours
-            severity: warning
-            slack: kub3-${cluster}-alerts-infra
+            ignore: never
+            severity: info
+            slack: kub3-${cluster}-notifications
             pagerduty: ignore
             incidentio: ignore
             team: platform
@@ -382,9 +382,9 @@ spec:
               `{{$labels.job_name}}` `Job`
             runbook: https://d.n3t.uk/runbooks/
           labels:
-            ignore: outside-extended-hours
-            severity: warning
-            slack: kub3-${cluster}-alerts-infra
+            ignore: never
+            severity: info
+            slack: kub3-${cluster}-notifications
             pagerduty: ignore
             incidentio: ignore
             team: platform
@@ -424,9 +424,9 @@ spec:
             dashboard: https://grafana.p.kub3.uk/
             runbook: https://d.n3t.uk/runbooks/
           labels:
-            ignore: outside-extended-hours
-            severity: warning
-            slack: kub3-${cluster}-alerts-infra
+            ignore: never
+            severity: info
+            slack: kub3-${cluster}-notifications
             pagerduty: ignore
             incidentio: ignore
             team: platform
@@ -505,9 +505,9 @@ spec:
             dashboard: https://grafana.p.kub3.uk/
             runbook: https://d.n3t.uk/runbooks/
           labels:
-            ignore: outside-extended-hours
-            severity: warning
-            slack: kub3-${cluster}-alerts-infra
+            ignore: never
+            severity: info
+            slack: kub3-${cluster}-notifications
             pagerduty: ignore
             incidentio: ignore
             team: platform

--- a/flux/prometheus-rules/workloads.yaml
+++ b/flux/prometheus-rules/workloads.yaml
@@ -54,17 +54,17 @@ spec:
             sum by (namespace, pod, phase) (
               max by (namespace, pod, phase) (
                 kube_pod_status_phase{
-                  phase!~"Running"
+                  phase!~"Running|Succeeded"
                 }
               ) * on(namespace, pod) group_left(owner_kind)
               max by(namespace, pod, phase, owner_kind) (
                 kube_pod_owner{
                   owner_kind!="Job"
                 }
-              ) * on (namespace, pod) group_left (node) (
-                group by (node, namespace, pod) (
-                  kube_pod_info
-                )
+              )
+            ) * on (namespace, pod) group_left (node) (
+              group by (node, namespace, pod) (
+                kube_pod_info
               )
             ) > 0
           for: 5m


### PR DESCRIPTION
Add support to Alertmanager for a new `notifications` channel alongside the `infra` and `applications` alerts channels. Selected Alerts, such as `Pods` passing memory or CPU requests or other unusual or informational alerts that should probably be actioned but do not directly affect normal operational stability, are now redirected there.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
