### PR TITLE
Disable the No New Documents Alert for ElasticSearch

### DIFF
--- a/flux/alertmanager/slack.yaml
+++ b/flux/alertmanager/slack.yaml
@@ -33,6 +33,7 @@ spec:
           - name: slack
             value: kub3-${cluster}-notifications
         continue: true
+        repeatInterval: 24h
     repeatInterval: 3h
     continue: true
 

--- a/flux/elastic-logs/prometheus-rules.yaml
+++ b/flux/elastic-logs/prometheus-rules.yaml
@@ -273,11 +273,13 @@ spec:
               `{{$labels.name}}` node in `{{$labels.namespace}}`/`{{$labels.cluster}}` Cluster
             runbook: https://d.n3t.uk/runbooks/
           labels:
-            ignore: outside-extended-hours
+            # At the moment there are not enough concurrent shards being processed which will always
+            # ensure that data nodes will alway sbe written to, so disable alerting for this rule
+            ignore: always
             severity: warning
             slack: kub3-${cluster}-alerts-infra
-            pagerduty: send
-            incidentio: send
+            pagerduty: ignore
+            incidentio: ignore
             team: platform
 
         - alert: ElasticSearchNoNewDocumentsCritical


### PR DESCRIPTION
Disable the individual node "No New Documents" Alert for ElasticSearch, as its not unusual for a node not to be written to when only a few shards are being processed. The "Critical" version of the alert still monitors when no documents are written to the ElasticSearch cluster as a whole, so it is still monitored.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
