### PR TITLE
INC-33: Upgrade `ingress-nginx` for CVE-2025-1984

### DIFF
--- a/flux/ingress-nginx/external/external-helm.yaml
+++ b/flux/ingress-nginx/external/external-helm.yaml
@@ -12,7 +12,7 @@ spec:
         name: ingress-nginx
       chart: ingress-nginx
       interval: 5m
-      version: 4.11.3
+      version: 4.12.1
   interval: 3h
   install:
     crds: CreateReplace

--- a/flux/ingress-nginx/internal/internal-helm.yaml
+++ b/flux/ingress-nginx/internal/internal-helm.yaml
@@ -12,7 +12,7 @@ spec:
         name: ingress-nginx
       chart: ingress-nginx
       interval: 5m
-      version: 4.11.3
+      version: 4.12.1
   interval: 3h
   install:
     crds: CreateReplace


### PR DESCRIPTION
Upgrade the `ingress-nginx` Helm Charts to `4.12.1` to install the `1.12.1` release of `ingress-nginx`, which has a fix for [CVE-2025-1974](https://kubernetes.io/blog/2025/03/24/ingress-nginx-cve-2025-1974/).

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
