### PR TITLE
INC-35: Rename `approver-policy` job in `PrometheusRules`

### DIFF
--- a/flux/cert-manager/prometheus-rules.yaml
+++ b/flux/cert-manager/prometheus-rules.yaml
@@ -26,7 +26,7 @@ spec:
               `cert-manager has Disappeared from Prometheus`
             summary: >-
               The `cert-manager` job in the `{{$externalLabels.cluster}}` Cluster has
-              *dissappeared* from Prometheus' service discovery and may not be running, or the
+              *disappeared* from Prometheus' service discovery and may not be running, or the
               `Service` may not be being scraped, and hence cannot be checked and monitored.
             description: >-
               `certificates-system`/`cert-manager` has *disappeared*
@@ -48,19 +48,19 @@ spec:
             absent(
               up{
                 namespace="certificates-system",
-                container="cert-manager-approver-policy"
+                container="approver-policy"
               } == 1
             )
           for: 30m
           annotations:
             title: >-
-              `cert-manager-approver-policy` has Disappeared from Prometheusg
+              `approver-policy` has Disappeared from Prometheus
             summary: >-
-              The `cert-manager-approver-policy` job in the `{{$externalLabels.cluster}}` Cluster
-              has *dissappeared* from Prometheus' service discovery and may not be running, or the
+              The `approver-policy` job in the `{{$externalLabels.cluster}}` Cluster has
+              *disappeared* from Prometheus' service discovery and may not be running, or the
               `Service` may not be being scraped, and hence cannot be checked and monitored.
             description: >-
-              `certificates-system`/`cert-manager` has *disappeared*
+              `certificates-system`/`approver-policy` has *disappeared*
           labels:
             ignore: outside-extended-hours
             severity: critical


### PR DESCRIPTION
Rename the `approver-policy` job in `PrometheusRules` to ensure that the correct check is performed against the Prometheus TSDB for the `approver-policy` service.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
