### PR TITLE
Add PrometheusRules recording rules and ElasticSearch Dashboard

### DIFF
--- a/flux/alertmanager/kustomization.yaml
+++ b/flux/alertmanager/kustomization.yaml
@@ -22,7 +22,7 @@ resources:
   - alertmanager.yaml
   - config.yaml
   - slack.yaml
-  - pagerduty.yaml
+  # - pagerduty.yaml
   - incidentio.yaml
   - service.yaml
   - service-monitor.yaml

--- a/flux/alertmanager/slack.yaml
+++ b/flux/alertmanager/slack.yaml
@@ -33,6 +33,7 @@ spec:
       - receiver: notifications
         matchers:
           - name: slack
+            matchType: =
             value: kub3-${cluster}-notifications
         continue: true
         repeatInterval: 24h

--- a/flux/elastic-logs/dashboard-service.json
+++ b/flux/elastic-logs/dashboard-service.json
@@ -889,7 +889,7 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 8
       },
@@ -944,6 +944,103 @@
         "defaults": {
           "color": {
             "fixedColor": "blue",
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "index": 0,
+                  "text": "(n/a)"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2000
+              },
+              {
+                "color": "orange",
+                "value": 2500
+              },
+              {
+                "color": "red",
+                "value": 3000
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 346,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "elasticsearch_cluster_health_active_shards{cluster=\"$esCluster\"} / on (namespace,cluster) (min by (namespace,cluster) (elasticsearch_jvm_memory_max_bytes{cluster=\"$esCluster\",es_master_node=\"true\",area=\"heap\"}) / (1024^3))",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "Shards per JVM GiB (Master) ",
+          "refId": "A",
+          "step": 60
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
             "mode": "fixed"
           },
           "decimals": 0,
@@ -975,8 +1072,8 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 16,
         "y": 8
       },
       "id": 7,
@@ -3256,7 +3353,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "logs-es-data-0",
             "logs-es-data-1",
@@ -3292,7 +3389,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "logs-audit",
             "logs-dashboard",
@@ -3349,6 +3446,6 @@
   "timezone": "browser",
   "title": "ElasticSearch Service",
   "uid": "aegcc31gpqwhsd",
-  "version": 49,
+  "version": 50,
   "weekStart": "monday"
 }

--- a/flux/elastic-logs/elastic-server.yaml
+++ b/flux/elastic-logs/elastic-server.yaml
@@ -53,7 +53,7 @@ spec:
             - name: elasticsearch
               env:
                 - name: ES_JAVA_OPTS
-                  value: -Xms4g -Xmx4g
+                  value: -Xms3g -Xmx3g
               resources:
                 limits:
                   memory: 6Gi

--- a/flux/elastic-logs/elasticsearch-exporter-helm.yaml
+++ b/flux/elastic-logs/elasticsearch-exporter-helm.yaml
@@ -14,7 +14,7 @@ spec:
         name: prometheus-community
       chart: prometheus-elasticsearch-exporter
       interval: 5m
-      version: 6.6.1
+      version: 6.7.2
   interval: 3h
   install:
     crds: CreateReplace

--- a/flux/elastic-logs/elasticsearch-exporter-values.yaml
+++ b/flux/elastic-logs/elasticsearch-exporter-values.yaml
@@ -31,10 +31,10 @@ es:
   aliases: false
   shards: true
   snapshots: false
-  cluster_settings: false
-  slm: false
-  data_stream: false
-  ilm: false
+  cluster_settings: true
+  slm: true
+  data_stream: true
+  ilm: true
   timeout: 10s
 
 serviceMonitor:

--- a/flux/fluent-bit/prometheus-rules.yaml
+++ b/flux/fluent-bit/prometheus-rules.yaml
@@ -53,7 +53,7 @@ spec:
                 kube_pod_info
               )
             ) > 0
-          for: 5m
+          for: 15m
           annotations:
             title: Excessive Drops Detected for Logs in Fluent Bit
             summary: >-

--- a/flux/prometheus/prometheus.yaml
+++ b/flux/prometheus/prometheus.yaml
@@ -53,7 +53,7 @@ spec:
 
   resources:
     limits: # Don't limit the CPU
-      memory: 1024Mi
+      memory: 1228Mi
     requests:
       cpu: 50m
       memory: 1024Mi


### PR DESCRIPTION
Upgrade ElasticSearch and add both recording rules via `PrometheusRules` and a copy of the Grafana dashboard for ElasticSearch (saved, but not installed via Kubernetes manifests).

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
