### PR TITLE
Remove the `reviewers` field for Dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,8 +15,6 @@ updates:
       - type/dependencies
       - update/github-workflows
       - release/chore
-    reviewers:
-      - n3tuk/infra-reviewers
 
   - package-ecosystem: terraform
     directory: terraform/
@@ -31,5 +29,3 @@ updates:
       - type/dependencies
       - update/terraform
       - release/chore
-    reviewers:
-      - n3tuk/infra-reviewers


### PR DESCRIPTION
The `reviewers` field in the Dependabot configuration file is deprecated and will be removed (or ignored) on 27 May 2025, so remove the setting.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
