### PR TITLE
Enable `promtool` Support in Taskfiles

### DIFF
--- a/.taskfiles/flux.yaml
+++ b/.taskfiles/flux.yaml
@@ -20,6 +20,45 @@ tasks:
           as: kustom
         cmd: echo "flux/{{ .kustom }}"
 
+  flux:promtool:
+    aliases:
+      - promtool
+    desc: Validate the recording rules and alerts in PrometheusRules
+    summary: |-
+      Check that the recording rules and alerts in PrometheusRules resources
+      are valid, including PromQL expressions and expected labels and
+      annotations, using the promtool.
+    silent: true
+    dir: flux
+    sources:
+      - '**/prometheus-rules.yaml'
+    vars:
+      files:
+        sh: |-
+          find . \
+            -ignore_readdir_race \
+            -type f \
+            -iname 'prometheus-rules.yaml' \
+            -printf '%P ' \
+          2> /dev/null || true
+    deps:
+      - task: yamllint
+      - task: flux:conform
+    cmds:
+      # yamllint disable rule:line-length
+      - for:
+          var: files
+          as: file
+        cmd: |-
+          yq '.spec' --yaml-roundtrip '{{.file}}' \
+          | promtool check rules --lint-fatal \
+          | sed -e 's|standard input|{{.file}}|' \
+                -e '/^$/d'
+
+      - cmd: |-
+          echo -e '{{ .cg }}Passed{{ .cc }}'
+      # yamllint enable rule:line-length
+
   flux:conform:
     aliases:
       - conform

--- a/.taskfiles/utils.yaml
+++ b/.taskfiles/utils.yaml
@@ -35,6 +35,7 @@ tasks:
       - task: check:kubeconform
       - task: check:check-jsonschema
       - task: check:markdownlint
+      - task: check:promtool
 
   # Run a check for a specific executable to ensure it's available within $PATH
   check:*:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -8,7 +8,7 @@ output: prefixed
 # there are issues with tasks running continuously, or being re-added to the
 # queue multiple times due to regular changes, increase the value for the watch
 # interval to take into account the typical longest running task in the set.
-interval: 5s
+# interval: 5s
 
 # Enforce the pipefail option in the Bash library to ensure that where commands
 # are run through pipes, the failure of any one step in the pipeline fails the
@@ -146,11 +146,15 @@ tasks:
         Terraform code is syntactically correct, properly formatted, and mostly
         valid for runtime (e.g. using correct instance types, names are not too
         long, and resource names are correctly formatted).
+      - Run promtool across all prometheus-rules.yaml, extracting all recording
+        rules and alerts from the PrometheusRule resources files to check them
+        for correctness.
     silent: true
     cmds:
       - task: prettier
       - task: markdownlint
       - task: jsonschema
+      - task: flux:promtool
 
   validate:
     desc: Validate the configurations and resources

--- a/flux/metallb/prometheus-rules.yaml
+++ b/flux/metallb/prometheus-rules.yaml
@@ -212,7 +212,7 @@ spec:
 
     - name: metallb-sessions
       rules:
-        - alert: MetalLBBGPSessionDown
+        - alert: MetalLBBGPSessionDownWarning
           expr: |-
             (
               metallb_speaker_announced{
@@ -242,7 +242,7 @@ spec:
             incidentio: send
             team: platform
 
-        - alert: MetalLBBGPSessionDown
+        - alert: MetalLBBGPSessionDownCritical
           expr: |-
             (
               metalb_bgp_session_up{
@@ -265,7 +265,7 @@ spec:
               `{{$labels.pod}}` `Pod` on `{{$labels.node}}` `Node` (`{{$labels.peer}}`)
           labels:
             ignore: outside-extended-hours
-            severity: warning
+            severity: critical
             slack: kub3-${cluster}-alerts-infra
             pagerduty: send
             incidentio: send


### PR DESCRIPTION
Enable use of the `promtool` utility from Prometheus to extract and check the PrometheusRules resources, validating the recording rules and alerts before submitting, via `flux`, to the Clusters.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
