### PR TITLE
Increase CPU and Memory Requests and Limits

### DIFF
--- a/flux/elastic-logs/elasticsearch-exporter-values.yaml
+++ b/flux/elastic-logs/elasticsearch-exporter-values.yaml
@@ -10,7 +10,7 @@ resources:
   limits: # Don't limit the CPU
     memory: 128Mi
   requests:
-    cpu: 50m
+    cpu: 100m
     memory: 64Mi
 
 extraEnvSecrets:

--- a/flux/prometheus/prometheus.yaml
+++ b/flux/prometheus/prometheus.yaml
@@ -53,10 +53,10 @@ spec:
 
   resources:
     limits: # Don't limit the CPU
-      memory: 1228Mi
+      memory: 1300Mi
     requests:
-      cpu: 50m
-      memory: 1024Mi
+      cpu: 75m
+      memory: 1100Mi
 
   logFormat: json
 


### PR DESCRIPTION
Increase some CPU and memory limits and requests for Prometheus and ElasticSearch Exporter, as these have recently increased beyond the baseline settings and are triggering alerts. This will ensure the baseline remains just above their typical usage.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
