### PR TITLE
Add rate limit override for `ingress-nginx` `PrometheusRules`

### DIFF
--- a/flux/ingress-nginx/prometheus-rules.yaml
+++ b/flux/ingress-nginx/prometheus-rules.yaml
@@ -30,6 +30,12 @@ spec:
               ),
               "job", "$1", "job", "^(.*)-metrics$"
             ) > 0.05
+            and
+            sum by (job, exported_namespace, ingress, host) (
+              rate(
+                nginx_ingress_controller_requests[5m]
+              )
+            ) > 10
           for: 3m
           annotations:
             title: Elevated `Ingress` Error Rates
@@ -67,6 +73,12 @@ spec:
               ),
               "job", "$1", "job", "^(.*)-metrics$"
             ) > 0.1
+            and
+            sum by (job, exported_namespace, ingress, host) (
+              rate(
+                nginx_ingress_controller_requests[5m]
+              )
+            ) > 10
           for: 3m
           annotations:
             title: Elevated `Ingress` Latency


### PR DESCRIPTION
Add a rate limit override for each of the `ingress-nginx` `PrometheusRules` to ensure that they are only triggered when `ingress-nginx` is processing more than ten requests per second. This should help reduce false-positive alerts when there is a sudden surge of bad or slow requests.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
