### PR TITLE
Update `merge` action for Mergify and improve comments

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,41 +1,42 @@
 ---
+# yamllint disable rule:line-length
+# yaml-language-server: $schema=https://github.com/Mergifyio/docs/raw/refs/heads/main/public/mergify-configuration-schema.json
+
 # When working with Dependabot and GitHub Actions, where those Actions can make
 # changes to documentation or code based on updates to the repository's
-# dependencies, it is always necessary for the pull requests to go through
-# multiple stagings using the force-ci-run label. These rules take this into
-# account and allow those stages to be managed and triggered as necessary.
+# dependencies, it is normally safe to automatically approve and merge these
+# changes so long as the integrations are successful.
 
 pull_request_rules:
-  # If the pull request was raised by Dependabot, and only Dependabot or GitHub
-  # Actions have make changes to the branch, then automatically approve if it's
-  # not in conflict with the base branch, and not closed.
   - name: Automatic approval for Dependabot pull requests
+    # If the pull request was raised by Dependabot, and only Dependabot or
+    # GitHub Actions have made changes to the branch, then automatically approve
+    # if it's not in conflict with the base branch, and not closed
     conditions:
-      - "author=dependabot[bot]"
-      - "base=main"
-      - "#commits-behind=0"
-      - "-conflict"
-      - "-closed"
+      - 'author=dependabot[bot]'
+      - 'base=main'
+      - '#commits-behind=0'
+      - '-conflict'
+      - '-closed'
       - or:
-          - "commits[*].author==dependabot[bot]"
-          - "commits[*].author==github-actions[bot]"
+          - 'commits[*].author==dependabot[bot]'
+          - 'commits[*].author==github-actions[bot]'
     actions:
       review:
         type: APPROVE
 
-  # If the pull request was raised by Dependabot, it only has a linear history,
-  # it has been approved for merging into the main or master branches, and is
-  # neither in conflict with the main branch, fallen behind, nor the
-  # force-ci-run label is still present, then automatically merge this request.
   - name: Automatic merge for Dependabot pull requests
+    # If the pull request was raised by Dependabot, it only has a linear
+    # history, it has been approved for merging into the main or master
+    # branches, and is neither in conflict with the main branch, nor fallen
+    # behind, then automatically merge this request
     conditions:
-      - "author=dependabot[bot]"
-      - "base=main"
-      - "linear-history"
-      - "#approved-reviews-by>=1"
-      - "-label=force-ci-run"
-      - "-conflict"
-      - "-closed"
+      - 'author=dependabot[bot]'
+      - 'base=main'
+      - 'linear-history'
+      - '#approved-reviews-by>=1'
+      - '-conflict'
+      - '-closed'
     actions:
       merge:
-        method: rebase
+        method: merge


### PR DESCRIPTION
Update the `merge` action for Mergify to use the standard `merge` setting, and update the comments to be more relevant to the actual steps taken, as `force-ci-run` is no longer a valid label.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
