### PR TITLE
Fix `topologySpreadConstraints` for HAProxy

### DIFF
--- a/.taskfiles/flux.yaml
+++ b/.taskfiles/flux.yaml
@@ -98,8 +98,7 @@ tasks:
           kubeconform \
             -kubernetes-version {{ .kubernetes_version }} \
             -ignore-missing-schemas \
-            -schema-location 'https://json.schemastore.org/{{.ResourceKind}}.json' \
-            -schema-location 'https://github.com/yannh/kubernetes-json-schema/raw/master/{{printf "{{.NormalizedKubernetesVersion}}{{.StrictSuffix}}/{{.ResourceKind}}{{.KindSuffix}}"}}.json' \
+            -schema-location default \
             -schema-location 'https://github.com/datreeio/crds-catalog/raw/main/{{printf "{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}"}}.json' \
             -cache .kubeconform \
             -output pretty \
@@ -113,8 +112,7 @@ tasks:
           kubeconform \
             -kubernetes-version {{ .kubernetes_version }} \
             -ignore-missing-schemas \
-            -schema-location 'https://json.schemastore.org/{{ .ResourceKind }}.json' \
-            -schema-location 'https://github.com/yannh/kubernetes-json-schema/raw/master/{{printf "{{.NormalizedKubernetesVersion}}{{.StrictSuffix}}/{{.ResourceKind}}{{.KindSuffix}}"}}.json' \
+            -schema-location default \
             -schema-location 'https://github.com/datreeio/crds-catalog/raw/main/{{printf "{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}"}}.json'\
             -cache .kubeconform \
             -output junit \

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -231,3 +231,10 @@ misconfigurations:
       # container "manager" of statefulset "elastic-operator" in "elastic-system" namespace should
       # specify a seccomp profile
       - elastic-crds/operator.yaml
+
+  - id: AVD-KSV-0125 # MEDIUM
+    # All container images must start with the *.azurecr.io domain
+    statement: >
+      There are currently no plans to locally cache any container images used in dedicated,
+      personally controlled registries as these clusters are mainly for learning and development
+      currently.

--- a/flux/ingress-haproxy/external/haproxy-values.yaml
+++ b/flux/ingress-haproxy/external/haproxy-values.yaml
@@ -89,14 +89,18 @@ controller:
       labelSelector:
         matchLabels:
           app.kubernetes.io/name: haproxy-external
-          app.kubernetes.io/instance: haproxy
+          app.kubernetes.io/instance: haproxy-external
+      matchLabelKeys:
+        - pod-template-hash
     - maxSkew: 1
       topologyKey: kubernetes.io/hostname
       whenUnsatisfiable: DoNotSchedule
       labelSelector:
         matchLabels:
           app.kubernetes.io/name: haproxy-external
-          app.kubernetes.io/instance: haproxy
+          app.kubernetes.io/instance: haproxy-external
+      matchLabelKeys:
+        - pod-template-hash
 
   strategy:
     type: RollingUpdate

--- a/flux/ingress-haproxy/internal/haproxy-values.yaml
+++ b/flux/ingress-haproxy/internal/haproxy-values.yaml
@@ -105,14 +105,18 @@ controller:
       labelSelector:
         matchLabels:
           app.kubernetes.io/name: haproxy-internal
-          app.kubernetes.io/instance: haproxy
+          app.kubernetes.io/instance: haproxy-internal
+      matchLabelKeys:
+        - pod-template-hash
     - maxSkew: 1
       topologyKey: kubernetes.io/hostname
       whenUnsatisfiable: DoNotSchedule
       labelSelector:
         matchLabels:
           app.kubernetes.io/name: haproxy-internal
-          app.kubernetes.io/instance: haproxy
+          app.kubernetes.io/instance: haproxy-internal
+      matchLabelKeys:
+        - pod-template-hash
 
   strategy:
     type: RollingUpdate

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -12,7 +12,7 @@ TODO
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.10.0 |
 | <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 4.23 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.6 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.36.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.37.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.7.1 |
 
 ## Providers
@@ -20,8 +20,8 @@ TODO
 | Name | Version |
 |------|---------|
 | <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | 4.52.0 |
-| <a name="provider_google"></a> [google](#provider\_google) | 6.35.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.36.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.37.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.37.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
 
 ## Modules


### PR DESCRIPTION
Fix the `topologySpreadConstraints` to consider the updated values for the `app.kubernetes.io/instance` key, and include the `pod-template-hash` key in the consideration.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
