### PR TITLE
Add Underutilisation Checks and Tune Pod Requests

### DIFF
--- a/.taskfiles/flux.yaml
+++ b/.taskfiles/flux.yaml
@@ -32,20 +32,28 @@ tasks:
     dir: flux
     sources:
       - '**/prometheus-rules.yaml'
+      - flux/prometheus-rules/*.yaml
+      - exclude: flux/prometheus-rules/kustomization.yaml
     vars:
       files:
         sh: |-
-          find . \
-            -ignore_readdir_race \
-            -type f \
-            -iname 'prometheus-rules.yaml' \
-            -printf '%P ' \
-          2> /dev/null || true
+          ( find . \
+              -ignore_readdir_race \
+              -type f \
+              -iname 'prometheus-rules.yaml' \
+              -printf '%P ' \
+            2> /dev/null && \
+            find prometheus-rules \
+              -ignore_readdir_race \
+              -type f \
+              -not -iname 'kustomization.yaml' \
+              -printf 'prometheus-rules/%P ' \
+            2> /dev/null
+          ) || true
     deps:
       - task: yamllint
       - task: flux:conform
     cmds:
-      # yamllint disable rule:line-length
       - for:
           var: files
           as: file
@@ -54,10 +62,8 @@ tasks:
           | promtool check rules --lint-fatal \
           | sed -e 's|standard input|{{.file}}|' \
                 -e '/^$/d'
-
       - cmd: |-
           echo -e '{{ .cg }}Passed{{ .cc }}'
-      # yamllint enable rule:line-length
 
   flux:conform:
     aliases:

--- a/flux/cloudflared/cloudflared-values.yaml
+++ b/flux/cloudflared/cloudflared-values.yaml
@@ -11,10 +11,10 @@ image:
 
 resources:
   limits: # Don't limit the CPU
-    memory: 256Mi
+    memory: 128Mi
   requests:
     cpu: 100m
-    memory: 128Mi
+    memory: 32Mi
 
 securityContext:
   seccompProfile:

--- a/flux/fluent-bit/fluent-bit-deployment-values.yaml
+++ b/flux/fluent-bit/fluent-bit-deployment-values.yaml
@@ -17,10 +17,10 @@ dashboards:
 
 resources:
   limits:
-    memory: 128Mi
+    memory: 64Mi
   requests:
     cpu: 10m
-    memory: 32Mi
+    memory: 16Mi
 
 hotReload:
   enabled: true

--- a/flux/ingress-haproxy/external/haproxy-values.yaml
+++ b/flux/ingress-haproxy/external/haproxy-values.yaml
@@ -76,7 +76,7 @@ controller:
       memory: 128Mi
     requests:
       cpu: 25m
-      memory: 64Mi
+      memory: 96Mi
 
   podDisruptionBudget:
     enable: true

--- a/flux/ingress-haproxy/internal/haproxy-values.yaml
+++ b/flux/ingress-haproxy/internal/haproxy-values.yaml
@@ -92,7 +92,7 @@ controller:
       memory: 128Mi
     requests:
       cpu: 25m
-      memory: 64Mi
+      memory: 96Mi
 
   podDisruptionBudget:
     enable: true

--- a/flux/ingress-nginx/external/ingress-nginx-values.yaml
+++ b/flux/ingress-nginx/external/ingress-nginx-values.yaml
@@ -23,7 +23,7 @@ controller:
       memory: 256Mi
     requests:
       cpu: 25m
-      memory: 128Mi
+      memory: 96Mi
 
   topologySpreadConstraints:
     - maxSkew: 1

--- a/flux/ingress-nginx/internal/ingress-nginx-values.yaml
+++ b/flux/ingress-nginx/internal/ingress-nginx-values.yaml
@@ -27,7 +27,7 @@ controller:
       memory: 256Mi
     requests:
       cpu: 25m
-      memory: 128Mi
+      memory: 96Mi
 
   topologySpreadConstraints:
     - maxSkew: 1

--- a/flux/kube-state-metrics/kube-state-metrics-values.yaml
+++ b/flux/kube-state-metrics/kube-state-metrics-values.yaml
@@ -31,4 +31,4 @@ resources:
     memory: 128Mi
   requests:
     cpu: 10m
-    memory: 96Mi
+    memory: 32Mi

--- a/flux/metallb/metallb-values.yaml
+++ b/flux/metallb/metallb-values.yaml
@@ -12,7 +12,7 @@ controller:
       memory: 256Mi
     request:
       cpu: 100m
-      memory: 64Mi
+      memory: 32Mi
 
 speaker:
   enabled: true
@@ -28,10 +28,10 @@ speaker:
   logLevel: info
   resources:
     limits:
-      memory: 256Mi
+      memory: 128Mi
     request:
       cpu: 100m
-      memory: 64Mi
+      memory: 32Mi
 
 crds:
   enabled: true

--- a/flux/metrics-server/metrics-server-values.yaml
+++ b/flux/metrics-server/metrics-server-values.yaml
@@ -44,4 +44,4 @@ resources:
     memory: 128Mi
   requests:
     cpu: 10m
-    memory: 96Mi
+    memory: 64Mi

--- a/flux/podinfo/podinfo-helm.yaml
+++ b/flux/podinfo/podinfo-helm.yaml
@@ -15,7 +15,7 @@ spec:
         name: podinfo
       chart: podinfo
       interval: 5m
-      version: 6.7.1
+      version: 6.9.0
   interval: 3h
   install:
     crds: CreateReplace

--- a/flux/podinfo/podinfo-values.yaml
+++ b/flux/podinfo/podinfo-values.yaml
@@ -43,7 +43,7 @@ ingress:
 
 resources:
   limits: # Don't limit the CPU
-    memory: 256Mi
+    memory: 64Mi
   requests:
     cpu: 10m
-    memory: 64Mi
+    memory: 17Mi

--- a/flux/prometheus-rules/persistent-volumes.yaml
+++ b/flux/prometheus-rules/persistent-volumes.yaml
@@ -13,24 +13,27 @@ spec:
     - name: persistent-volume-claims
       rules:
         - alert: PersistentVolumeClaimUsageWarning
-          expr: |-
-            kubelet_volume_stats_available_bytes{
-              job="kubelet",
-              metrics_path="/metrics"
-            } /
-            kubelet_volume_stats_capacity_bytes{
-              job="kubelet",
-              metrics_path="/metrics"
-            } < 0.25
+          expr: |2-
+              kubelet_volume_stats_available_bytes{
+                job="kubelet",
+                metrics_path="/metrics"
+              }
+            / kubelet_volume_stats_capacity_bytes{
+                job="kubelet",
+                metrics_path="/metrics"
+              }
+            < 0.20
           for: 1m
           annotations:
-            summary: PersistentVolumeClaim has <25% Free
+            title: >-
+              `PersistentVolumeClaim` is Filling Up
+            summary: >-
+              One or more `PersistentVolumeClaims` on the `{{$externalLabels.cluster}}` Cluster is
+              reporting as having *less than 20% of its total available capacity free*, which is
+              below the *warning* limit.
             description: >-
-              The `{{$labels.namespace}}`/`{{$labels.persistentvolumeclaim}}`
-              `PersistentVolumeClaim` on the `{{$externalLabels.cluster}}`
-              Cluster is reporting as having **{{$value|humanizePercentage}}**
-              of its total capacity remaining, which is below the **warning**
-              limit.
+              `{{$labels.namespace}}/{{$labels.persistentvolumeclaim}}`
+              (*{{$value|humanizePercentage}}*)
             dashboard: https://grafana.${cluster_domain}/
             runbook: https://d.n3t.uk/runbooks/
           labels:
@@ -47,24 +50,27 @@ spec:
             team: platform
 
         - alert: PersistentVolumeClaimUsageCritical
-          expr: |-
-            kubelet_volume_stats_available_bytes{
-              job="kubelet",
-              metrics_path="/metrics"
-            } /
-            kubelet_volume_stats_capacity_bytes{
-              job="kubelet",
-              metrics_path="/metrics"
-            } < 0.05
+          expr: |2-
+              kubelet_volume_stats_available_bytes{
+                job="kubelet",
+                metrics_path="/metrics"
+              }
+            / kubelet_volume_stats_capacity_bytes{
+                job="kubelet",
+                metrics_path="/metrics"
+              }
+            < 0.05
           for: 1m
           annotations:
-            summary: PersistentVolumeClaim has <5% Free
+            title: >-
+              `PersistentVolumeClaim` is Almost Full
+            summary: >-
+              One or more `PersistentVolumeClaims` on the `{{$externalLabels.cluster}}` Cluster is
+              reporting as having less *than 5% of its total available capacity free*, which is
+              below the *critical* limit.
             description: >-
-              The `{{$labels.namespace}}`/`{{$labels.persistentvolumeclaim}}`
-              `PersistentVolumeClaim` on the `{{$externalLabels.cluster}}`
-              Cluster is reporting as having **{{$value|humanizePercentage}}**
-              of its total capacity remaining, which is below the **critical**
-              limit.
+              `{{$labels.namespace}}/{{$labels.persistentvolumeclaim}}`
+              (*{{$value|humanizePercentage}}*)
             dashboard: https://grafana.${cluster_domain}/
             runbook: https://d.n3t.uk/runbooks/
           labels:
@@ -82,8 +88,8 @@ spec:
                 kubelet_volume_stats_available_bytes{
                   job="kubelet",
                   metrics_path="/metrics"
-                } /
-                kubelet_volume_stats_capacity_bytes{
+                }
+              / kubelet_volume_stats_capacity_bytes{
                   job="kubelet",
                   metrics_path="/metrics"
                 }
@@ -99,13 +105,16 @@ spec:
             )
           for: 30m
           annotations:
-            summary: PersistentVolumeClaim Nearing Capacity in 7d
+            title: >-
+              `PersistentVolumeClaim` Nearing Capacity within 7d
+            summary: >-
+              One or more `PersistentVolumeClaims` on the `{{$externalLabels.cluster}}` Cluster is
+              reporting as having *less than 30% of its total available capacity free*, and, based
+              on current rates of storage, *will fill within the next seven days*, which is below
+              the *warning* limit.
             description: >-
-              The `{{$labels.namespace}}`/`{{$labels.persistentvolumeclaim}}`
-              `PersistentVolumeClaim` on the `{{$externalLabels.cluster}}`
-              Cluster is reporting as having **{{$value|humanizePercentage}}**
-              of its total capacity remaining, **and is expected to fill within
-              the next seven days**, which is below the **warning** limit.
+              `{{$labels.namespace}}/{{$labels.persistentvolumeclaim}}`
+              (*{{$value|humanizePercentage}}*)
             dashboard: https://grafana.${cluster_domain}/
             runbook: https://d.n3t.uk/runbooks/
           labels:
@@ -123,8 +132,8 @@ spec:
                 kubelet_volume_stats_available_bytes{
                   job="kubelet",
                   metrics_path="/metrics"
-                } /
-                kubelet_volume_stats_capacity_bytes{
+                }
+              / kubelet_volume_stats_capacity_bytes{
                   job="kubelet",
                   metrics_path="/metrics"
                 }
@@ -140,13 +149,16 @@ spec:
             )
           for: 30m
           annotations:
-            summary: PersistentVolumeClaim at Capacity in 2d
+            title: >-
+              `PersistentVolumeClaim` at Capacity within 2d
+            summary: >-
+              One or more `PersistentVolumeClaims` on the `{{$externalLabels.cluster}}` Cluster is
+              reporting as having *less than 30% of its total avilable capacity free*, and, based
+              on current rates of storage, *will fill within the next two days*, which is below
+              the *critical* limit.
             description: >-
-              The `{{$labels.namespace}}`/`{{$labels.persistentvolumeclaim}}`
-              `PersistentVolumeClaim` on the `{{$externalLabels.cluster}}`
-              Cluster is reporting as having **{{$value|humanizePercentage}}**
-              of its total capacity remaining, **and is expected to fill within
-              the next two days**, which is below the **critical** limit.
+              `{{$labels.namespace}}/{{$labels.persistentvolumeclaim}}`
+              (*{{$value|humanizePercentage}}*)
             dashboard: https://grafana.${cluster_domain}/
             runbook: https://d.n3t.uk/runbooks/
           labels:
@@ -164,11 +176,15 @@ spec:
             } > 0
           for: 2m
           annotations:
-            summary: PersistentVolume is Pending or Failed
+            title: >-
+              `PersistentVolume` is Pending or Failed
+            summary: >-
+              One or more `PersistentVolumes` on the `{{$externalLabels.cluster}}` Cluster is
+              reporting as being in a `Pending` or `Failed` state and therefore may be preventing
+              normal operations of the attached `Pod`.
             description: >-
-              The `{{$labels.persistentvolume}}` `PersistentVolume` on the
-              `{{$externalLabels.cluster}}` Cluster is reporting as in the
-              `{{$labels.phase}}` phase.
+              `{{$labels.namespace}}/{{$labels.persistentvolume}}` `PersistentVolume`
+              (`{{$labels.phase}}` phase)
             dashboard: https://grafana.${cluster_domain}/
             runbook: https://d.n3t.uk/runbooks/
           labels:
@@ -186,12 +202,15 @@ spec:
             } > 0
           for: 2m
           annotations:
-            summary: PersistentVolumeClaim Pending or Lost
+            title: >-
+              `PersistentVolumeClaim` is Pending or Lost
+            summary: >-
+              One or more `PersistentVolumeClaims` on the `{{$externalLabels.cluster}}` Cluster is
+              reporting as being in a `Pending` or `Lost` state and therefore may be preventing
+              normal operations of the attached `Pod` or `StatefulSet`.
             description: >-
-              The `{{$labels.namespace}}`/`{{$labels.persistentvolumeclaim}}`
-              `PersistentVolumeClaim` on the `{{$externalLabels.cluster}}`
-              Cluster is reporting as having {{$value}} `PersistenVolume{{if ne
-              $value 1}}s{{end}}` in the `{{$labels.phase}}` phase.
+              `{{$labels.namespace}}/{{$labels.persistentvolumeclaim}}` `PersistentVolumeClaim`
+              (`{{$labels.phase}}` phase)
             dashboard: https://grafana.${cluster_domain}/
             runbook: https://d.n3t.uk/runbooks/
           labels:

--- a/flux/prometheus-rules/workloads.yaml
+++ b/flux/prometheus-rules/workloads.yaml
@@ -391,14 +391,183 @@ spec:
             incidentio: ignore
             team: platform
 
-    - name: workload-resources
+    - name: workload-resources-cpu
       rules:
-        - alert: PodMemoryRequests
+        - alert: PodCPURequestsUnderutilised
+          expr: |-
+            (
+              max by (namespace, pod, container) (
+                rate(
+                  container_cpu_usage_seconds_total{
+                    container!=""
+                  }[1h]
+                )
+              )
+            / min by (namespace, pod, container) (
+                kube_pod_container_resource_requests{
+                  resource="cpu"
+                }
+              )
+            * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
+            ) < 0.5
+          for: 24h
+          annotations:
+            title: >-
+              `Pods` Underutilising CPU Requests
+            summary: >-
+              Containers in one or more `Pods` on the `{{$externalLabels.cluster}}` Cluster have
+              *only used 50%, or less, of their requested CPU allocation* for the last twenty-four
+              hours, which is below the *warning* threshold.
+            description: >-
+              `{{$labels.container}}` container in `Pod` `{{$labels.pod}}`
+              (*{{$value|humanizePercentage}}* of `requests.cpu`)
+            dashboard: https://grafana.${cluster_domain}/
+            runbook: https://d.n3t.uk/runbooks/
+          labels:
+            ignore: outside-non-work-hours
+            severity: info
+            slack: kub3-${cluster}-notifications
+            pagerduty: ignore
+            incidentio: ignore
+            team: platform
+
+        - alert: PodCPURequestsWarning
+          expr: |-
+            (
+              max by (namespace, pod, container) (
+                rate(
+                  container_cpu_usage_seconds_total{
+                    pod!~"^kube-((?:apiserver|scheduler)-controller-0[1-3]|controller-manager-0[1-3]|flannel-[a-z]{5})$",
+                    container!=""
+                  }[3m]
+                )
+              )
+            / min by (namespace, pod, container) (
+                kube_pod_container_resource_requests{
+                  resource="cpu"
+                }
+              )
+            * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
+            ) > 1
+          for: 3h
+          annotations:
+            title: >-
+              `Pods` Exceeded CPU Requests
+            summary: >-
+              Containers in one or more `Pods` on the `{{$externalLabels.cluster}}` Cluster have
+              *exceeded 100% of their requested CPU allocation* for the last three hours, which is
+              above the *warning* threshold.
+            description: >-
+              `{{$labels.container}}` container in `Pod` `{{$labels.pod}}`
+              (*{{$value|humanizePercentage}}* of `requests.cpu`)
+            dashboard: https://grafana.${cluster_domain}/
+            runbook: https://d.n3t.uk/runbooks/
+          labels:
+            ignore: never
+            severity: info
+            slack: kub3-${cluster}-notifications
+            pagerduty: ignore
+            incidentio: ignore
+            team: platform
+
+        - alert: PodCPULimitsCritical
+          expr: |-
+            ( max by (namespace, pod, container) (
+                rate(
+                  container_cpu_usage_seconds_total{
+                    pod!~"^kube-((?:apiserver|scheduler)-controller-0[1-3]|controller-manager-0[1-3]|flannel-[a-z]{5})$",
+                    container!=""
+                  }[3m]
+                )
+              )
+            / min by (namespace, pod, container) (
+                kube_pod_container_resource_limits{
+                  resource="cpu"
+                }
+              )
+            * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
+            ) > 0.975
+          for: 15m
+          annotations:
+            title: >-
+              `Pods` Nearing CPU Limits
+            summary: >-
+              Containers in one or more `Pods` on the `{{$externalLabels.cluster}}` Cluster have
+              *passed 97.5% of the configured CPU limit* for at least the last fifteen minutes,
+              which is above the *critical* threshold.
+            description: >-
+              `{{$labels.container}}` container in `Pod` `{{$labels.pod}}`
+              (*{{$value|humanizePercentage}}* of `limits.cpu`)
+            dashboard: https://grafana.${cluster_domain}/
+            runbook: https://d.n3t.uk/runbooks/
+          labels:
+            ignore: outside-non-work-hours
+            severity: critical
+            slack: kub3-${cluster}-alerts-infra
+            pagerduty: send
+            incidentio: create
+            team: platform
+
+    - name: workload-resources-memory
+      rules:
+        - alert: PodMemoryRequestsUnderutilised
           expr: |-
             (
               max by (namespace, pod, container) (
                 container_memory_working_set_bytes{
                   pod!~"^kube-apiserver-controller-0[1-3]$",
+                  container!=""
+                }
+              ) /
+              min by (namespace, pod, container) (
+                kube_pod_container_resource_requests{
+                  resource="memory"
+                }
+              ) * on (namespace, pod) group_left (node) (
+                group by (node, namespace, pod) (
+                  kube_pod_info
+                )
+              )
+            ) < 0.5
+          for: 24h
+          annotations:
+            title: >-
+              `Pods` Underutilising Memory Requests
+            summary: >-
+              Containers in one or more `Pods` on the `{{$externalLabels.cluster}}` Cluster have
+              *only used 50%, or less, of their requested memory allocation* for the last
+              twenty-four hours, which is below the *warning* threshold.
+            description: >-
+              `{{$labels.container}}` container in `Pod` `{{$labels.pod}}`
+              (*{{$value|humanizePercentage}}* of `requests.memory`)
+            dashboard: https://grafana.${cluster_domain}/
+            runbook: https://d.n3t.uk/runbooks/
+          labels:
+            ignore: never
+            severity: info
+            slack: kub3-${cluster}-notifications
+            pagerduty: ignore
+            incidentio: ignore
+            team: platform
+
+        - alert: PodMemoryRequestsWarning
+          expr: |-
+            (
+              max by (namespace, pod, container) (
+                container_memory_working_set_bytes{
+                  pod!~"^kube-((?:apiserver|scheduler)-controller-0[1-3]|controller-manager-0[1-3]|flannel-[a-z]{5})$",
                   container!=""
                 }
               ) /
@@ -417,13 +586,13 @@ spec:
             title: >-
               `Pods` Exceeding Memory Requests
             summary: >-
-              One or more containers in `Pods` on the `{{$externalLabels.cluster}}` Cluster have
+              Containers in one or more `Pods` on the `{{$externalLabels.cluster}}` Cluster have
               *exceeded 100% of their requested memory allocation* for the last three hours, which
-              is above the *warning* limit.
+              is above the *warning* threshold.
             description: >-
               `{{$labels.container}}` container in `Pod` `{{$labels.pod}}`
-              (*{{$value|humanizePercentage}}* of `requests`)
-            dashboard: https://grafana.p.kub3.uk/
+              (*{{$value|humanizePercentage}}* of `requests.memory`)
+            dashboard: https://grafana.${cluster_domain}/
             runbook: https://d.n3t.uk/runbooks/
           labels:
             ignore: never
@@ -433,12 +602,12 @@ spec:
             incidentio: ignore
             team: platform
 
-        - alert: PodMemoryLimits
+        - alert: PodMemoryLimitsCritical
           expr: |-
             (
               max by (namespace, pod, container) (
                 container_memory_working_set_bytes{
-                  pod!~"^kube-apiserver-controller-0[1-3]$",
+                  pod!~"^kube-((?:apiserver|scheduler)-controller-0[1-3]|controller-manager-0[1-3]|flannel-[a-z]{5})$",
                   container!=""
                 }
               ) /
@@ -462,89 +631,8 @@ spec:
               which is above the *critical* limit.
             description: >-
               `{{$labels.container}}` container of `Pod` `{{$labels.pod}}`
-              (*{{$value|humanizePercentage}} of* `limits`)
-            dashboard: https://grafana.p.kub3.uk/
-            runbook: https://d.n3t.uk/runbooks/
-          labels:
-            ignore: outside-non-work-hours
-            severity: critical
-            slack: kub3-${cluster}-alerts-infra
-            pagerduty: send
-            incidentio: create
-            team: platform
-
-        - alert: PodCPURequests
-          expr: |-
-            (
-              max by (namespace, pod, container) (
-                rate(
-                  container_cpu_usage_seconds_total{
-                    container!=""
-                  }[3m]
-                )
-              ) /
-              min by (namespace, pod, container) (
-                kube_pod_container_resource_requests{
-                  resource="cpu"
-                }
-              ) * on (namespace, pod) group_left (node) (
-                group by (node, namespace, pod) (
-                  kube_pod_info
-                )
-              )
-            ) > 1
-          for: 3h
-          annotations:
-            title: >-
-              `Pods` Exceeding CPU Requests
-            summary: >-
-              One or more containers in `Pods` on the `{{$externalLabels.cluster}}` Cluster have
-              *exceeded 100% of their requested CPU allocation* for the last three hours, which is
-              above the *warning* limit.
-            description: >-
-              `{{$labels.container}}` container in `Pod` `{{$labels.pod}}`
-              (*{{$value|humanizePercentage}}* of `requests`)
-            dashboard: https://grafana.p.kub3.uk/
-            runbook: https://d.n3t.uk/runbooks/
-          labels:
-            ignore: never
-            severity: info
-            slack: kub3-${cluster}-notifications
-            pagerduty: ignore
-            incidentio: ignore
-            team: platform
-
-        - alert: PodCPULimits
-          expr: |-
-            ( max by (namespace, pod, container) (
-                rate(
-                  container_cpu_usage_seconds_total{
-                    container!=""
-                  }[3m]
-                )
-              ) /
-              min by (namespace, pod, container) (
-                kube_pod_container_resource_limits{
-                  resource="cpu"
-                }
-              ) * on (namespace, pod) group_left (node) (
-                group by (node, namespace, pod) (
-                  kube_pod_info
-                )
-              )
-            ) > 0.975
-          for: 15m
-          annotations:
-            title: >-
-              `Pods` Nearing CPU Limits
-            summary: >-
-              One or more containers in `Pods` on the `{{$externalLabels.cluster}}` Cluster have
-              *passed 97.5% of the configured CPU limit* for at least the last fifteen minutes,
-              which is above the *critical* limit.
-            description: >-
-              `{{$labels.container}}` container in `Pod` `{{$labels.pod}}`
-              (*{{$value|humanizePercentage}}* of `limits`)
-            dashboard: https://grafana.p.kub3.uk/
+              (*{{$value|humanizePercentage}} of* `limits.memory`)
+            dashboard: https://grafana.${cluster_domain}/
             runbook: https://d.n3t.uk/runbooks/
           labels:
             ignore: outside-non-work-hours

--- a/flux/prometheus-rules/workloads.yaml
+++ b/flux/prometheus-rules/workloads.yaml
@@ -399,6 +399,7 @@ spec:
               max by (namespace, pod, container) (
                 rate(
                   container_cpu_usage_seconds_total{
+                    pod!~"^kube-((?:apiserver|scheduler)-controller-0[1-3]|controller-manager-0[1-3]|flannel-[a-z]{5})$",
                     container!=""
                   }[1h]
                 )
@@ -414,6 +415,10 @@ spec:
                 )
               )
             ) < 0.5
+            and
+            kube_pod_container_resource_requests{
+              resource="cpu"
+            } > 0.05
           for: 24h
           annotations:
             title: >-
@@ -527,7 +532,7 @@ spec:
             (
               max by (namespace, pod, container) (
                 container_memory_working_set_bytes{
-                  pod!~"^kube-apiserver-controller-0[1-3]$",
+                  pod!~"^kube-((?:apiserver|scheduler)-controller-0[1-3]|controller-manager-0[1-3]|flannel-[a-z]{5})$",
                   container!=""
                 }
               ) /
@@ -541,6 +546,10 @@ spec:
                 )
               )
             ) < 0.5
+            and
+            kube_pod_container_resource_requests{
+              resource="memory"
+            } > (16 * 1024^2)
           for: 24h
           annotations:
             title: >-

--- a/flux/prometheus/prometheus.yaml
+++ b/flux/prometheus/prometheus.yaml
@@ -53,10 +53,10 @@ spec:
 
   resources:
     limits: # Don't limit the CPU
-      memory: 1300Mi
+      memory: 1434Mi
     requests:
       cpu: 75m
-      memory: 1100Mi
+      memory: 1228Mi
 
   logFormat: json
 

--- a/flux/sources/cloudflare.yaml
+++ b/flux/sources/cloudflare.yaml
@@ -5,6 +5,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: cloudflare
+  namespace: flux-system
 spec:
   url: https://cloudflare.github.io/helm-charts
   interval: 24h

--- a/flux/sources/elastic.yaml
+++ b/flux/sources/elastic.yaml
@@ -5,6 +5,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: elastic
+  namespace: flux-system
 spec:
   url: https://helm.elastic.co
   interval: 24h

--- a/flux/sources/external-dns.yaml
+++ b/flux/sources/external-dns.yaml
@@ -5,6 +5,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: external-dns
+  namespace: flux-system
 spec:
   url: https://kubernetes-sigs.github.io/external-dns/
   interval: 24h

--- a/flux/sources/fluent.yaml
+++ b/flux/sources/fluent.yaml
@@ -5,6 +5,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: fluent
+  namespace: flux-system
 spec:
   url: https://fluent.github.io/helm-charts
   interval: 24h

--- a/flux/sources/flux-community.yaml
+++ b/flux/sources/flux-community.yaml
@@ -5,6 +5,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: flux-community
+  namespace: flux-system
 spec:
   url: https://fluxcd-community.github.io/helm-charts
   interval: 24h

--- a/flux/sources/grafana.yaml
+++ b/flux/sources/grafana.yaml
@@ -5,6 +5,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: grafana
+  namespace: flux-system
 spec:
   url: https://grafana.github.io/helm-charts
   interval: 24h

--- a/flux/sources/haproxytech.yaml
+++ b/flux/sources/haproxytech.yaml
@@ -5,6 +5,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: haproxytech
+  namespace: flux-system
 spec:
   url: https://haproxytech.github.io/helm-charts
   interval: 24h

--- a/flux/sources/ingress-nginx.yaml
+++ b/flux/sources/ingress-nginx.yaml
@@ -5,6 +5,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: ingress-nginx
+  namespace: flux-system
 spec:
   url: https://kubernetes.github.io/ingress-nginx
   interval: 24h

--- a/flux/sources/jetstack.yaml
+++ b/flux/sources/jetstack.yaml
@@ -5,6 +5,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: jetstack
+  namespace: flux-system
 spec:
   url: https://charts.jetstack.io
   interval: 24h

--- a/flux/sources/kedacore.yaml
+++ b/flux/sources/kedacore.yaml
@@ -5,6 +5,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kedacore
+  namespace: flux-system
 spec:
   url: https://kedacore.github.io/charts
   interval: 24h

--- a/flux/sources/metallb.yaml
+++ b/flux/sources/metallb.yaml
@@ -5,6 +5,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: metallb
+  namespace: flux-system
 spec:
   url: https://metallb.github.io/metallb
   interval: 24h

--- a/flux/sources/metrics-server.yaml
+++ b/flux/sources/metrics-server.yaml
@@ -5,6 +5,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: metrics-server
+  namespace: flux-system
 spec:
   url: https://kubernetes-sigs.github.io/metrics-server/
   interval: 24h

--- a/flux/sources/podinfo.yaml
+++ b/flux/sources/podinfo.yaml
@@ -5,6 +5,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: podinfo
+  namespace: flux-system
 spec:
   url: https://stefanprodan.github.io/podinfo
   interval: 24h

--- a/flux/sources/prometheus-community.yaml
+++ b/flux/sources/prometheus-community.yaml
@@ -5,6 +5,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: prometheus-community
+  namespace: flux-system
 spec:
   url: https://prometheus-community.github.io/helm-charts
   interval: 24h

--- a/flux/sources/proxmox-csi.yaml
+++ b/flux/sources/proxmox-csi.yaml
@@ -5,6 +5,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: OCIRepository
 metadata:
   name: proxmox-csi-plugin
+  namespace: flux-system
 spec:
   secretRef:
     name: ghcr-login

--- a/terraform/cloudflare-tunnel.tf
+++ b/terraform/cloudflare-tunnel.tf
@@ -23,20 +23,28 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "cluster" {
   tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.cluster.id
 
   config {
+    ingress_rule {
+      hostname = "dashboard.t3st.uk"
+      service  = "http://haproxy-external.ingress-system.svc"
+      origin_request {
+        connect_timeout = "3s"
+      }
+    }
+
     dynamic "ingress_rule" {
       for_each = local.cloudflare_domains
 
       content {
         hostname = "*.${ingress_rule.value}"
-        service  = "http://external-controller.ingress-system.svc"
+        service  = "http://nginx-external-controller.ingress-system.svc"
         origin_request {
-          connect_timeout = "10s"
+          connect_timeout = "3s"
         }
       }
     }
 
     ingress_rule {
-      service = "http://external-controller.ingress-nginx.svc"
+      service = "http://nginx-external-controller.ingress-nginx.svc"
     }
   }
 }


### PR DESCRIPTION
Create an additional workload check which monitors for underutilization of requested resources (i.e. less than 50% of that requested sustained) with a minimum baseline for checks. Also, tune the `requests` and `limits` for some `Pods` based on these new checks.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
